### PR TITLE
Pmd: Cleanup and Re-enable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,7 @@ checkstyle {
 
 pmd {
   toolVersion = "6.18.0"
-  ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
+  sourceSets = [sourceSets.main]
   reportsDir = file("$project.buildDir/reports/pmd")
   // https://github.com/pmd/pmd/issues/876
   ruleSets = []

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/WelcomeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/WelcomeTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.Matchers.containsString;
 @RunWith(SpringIntegrationSerenityRunner.class)
 @SpringBootTest
 @ActiveProfiles("functional")
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.LawOfDemeter", "PMD.BeanMembersShouldSerialize"})
 public class WelcomeTest {
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/config/SwaggerPublisherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/config/SwaggerPublisherTest.java
@@ -29,7 +29,6 @@ class SwaggerPublisherTest {
 
     @DisplayName("Generate swagger documentation")
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void generateDocs() throws Exception {
         byte[] specs = mvc.perform(get("/v2/api-docs"))
             .andExpect(status().isOk())

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/RootController.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.controllers;
 
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -22,12 +21,6 @@ public class RootController {
     private static final String INSTANCE_ID = UUID.randomUUID().toString();
     private static final String MESSAGE = "Welcome to wa-task-management-api";
 
-    private final String testProperty;
-
-    public RootController(@Value("${testProperty}") String testProperty) {
-        this.testProperty = testProperty;
-    }
-
     /**
      * Root GET endpoint.
      *
@@ -47,6 +40,6 @@ public class RootController {
         return ResponseEntity
             .ok()
             .cacheControl(CacheControl.noCache())
-            .body("Welcome to wa-task-management-api [\"" + testProperty + "\"]");
+            .body(MESSAGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/RootControllerTest.java
@@ -11,8 +11,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class RootControllerTest {
 
-    private static final String demoSecret = "demoSecret";
-    private final RootController rootController = new RootController(demoSecret);
+    private final RootController rootController = new RootController();
 
     @Test
     public void should_return_welcome_response() {
@@ -23,7 +22,7 @@ public class RootControllerTest {
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertThat(
             responseEntity.getBody(),
-            containsString("Welcome to wa-task-management-api [\"demoSecret\"]")
+            containsString("Welcome to wa-task-management-api")
         );
     }
 }


### PR DESCRIPTION
### Change description ###

Re-enables pmd failures changed source set to only scan src/main and cleanup

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
