### PR TITLE
Adding initial Open API docs and skeleton entities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,10 @@ sonarqube {
     property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
     property "sonar.pitest.mode", "reuseReport"
     property "sonar.pitest.reportsDirectory", "build/reports/pitest"
+    property "sonar.exclusions", "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/config/**," +
+                                 "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/SystemDateProvider.java," +
+                                 "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/Application.java"
+
   }
 }
 
@@ -167,10 +171,22 @@ dependencyCheck {
   failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
   suppressionFile = 'config/owasp/suppressions.xml'
 
+  // excludes *Test* source configurations from scan
+  skipConfigurations = configurations.collect { it.name }.findAll { it.contains('Test') }
+
   analyzers {
     // Disable scanning of .NET related binaries
     assemblyEnabled = false
   }
+}
+
+configurations {
+  integrationTestCompile.extendsFrom testCompile
+  integrationTestRuntime.extendsFrom testRuntime
+  functionalTestCompile.extendsFrom testCompile
+  functionalTestRuntime.extendsFrom testRuntime
+  contractTestCompile.extendsFrom testCompile
+  contractTestRuntime.extendsFrom testRuntime
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,6 @@ sonarqube {
     property "sonar.pitest.mode", "reuseReport"
     property "sonar.pitest.reportsDirectory", "build/reports/pitest"
     property "sonar.exclusions", "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/config/**," +
-                                 "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/SystemDateProvider.java," +
                                  "src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/Application.java"
 
   }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
@@ -1,22 +1,37 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.controllers;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.AssignTaskRequest;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.response.GetTaskResponse;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.response.GetTasksResponse;
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CamundaService;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+import java.util.Objects;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@SuppressWarnings({
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.UnusedPrivateField",
+    "PMD.SingularField"
+})
 @RequestMapping(
     path = "/task",
-    consumes = MediaType.APPLICATION_JSON_VALUE,
-    produces = MediaType.APPLICATION_JSON_VALUE
+    consumes = APPLICATION_JSON_VALUE,
+    produces = APPLICATION_JSON_VALUE
 )
 @RestController
 public class TaskController {
@@ -28,36 +43,183 @@ public class TaskController {
         this.camundaService = camundaService;
     }
 
-    @PostMapping
-    public ResponseEntity<String> searchWithCriteria() {
+    @ApiOperation("Retrieve a list of Task resources identified by set of search criteria.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 200,
+            message = "OK",
+            response = GetTasksResponse.class
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @PostMapping(produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetTasksResponse<CamundaTask>> searchWithCriteria() {
         throw new NotImplementedException();
     }
 
-    @GetMapping(path = "/{task-id}")
-    public ResponseEntity<String> getTask(@PathVariable("task-id") String id) {
-        String apiResponse = camundaService.getTask(id);
+    @ApiOperation("Retrieve a Task Resource identified by its unique id.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 200,
+            message = "OK",
+            response = GetTaskResponse.class
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @GetMapping(path = "/{task-id}", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetTaskResponse<CamundaTask>> getTask(@PathVariable("task-id") String id) {
         return ResponseEntity
             .ok()
             .cacheControl(CacheControl.noCache())
-            .body(apiResponse);
+            .body(new GetTaskResponse<>(new CamundaTask(id)));
     }
 
-    @PostMapping(path = "/{task-id}/claim")
+    @ApiOperation("Claim the identified Task for the currently logged in user.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 204,
+            message = "No Content"
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @PostMapping(path = "/{task-id}/claim",
+        produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> claimTask(@PathVariable("task-id") String taskId) {
         throw new NotImplementedException();
     }
 
-    @PostMapping(path = "/{task-id}/unclaim")
+    @ApiOperation("Unclaim the identified Task for the currently logged in user.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 204,
+            message = "No Content"
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @PostMapping(path = "/{task-id}/unclaim",
+        produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> unclaimTask(@PathVariable("task-id") String taskId) {
         throw new NotImplementedException();
     }
 
+    @ApiOperation("Assign the identified Task to a specified user.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 204,
+            message = "No Content"
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
     @PostMapping(path = "/{task-id}/assign")
-    public ResponseEntity<String> assignTask(@PathVariable("task-id") String taskId) {
+    public ResponseEntity<String> assignTask(@PathVariable("task-id") String taskId,
+                                             @RequestBody AssignTaskRequest assignTaskRequest) {
+
+        Objects.requireNonNull(assignTaskRequest);
+        Objects.requireNonNull(assignTaskRequest.getUserId());
+
         throw new NotImplementedException();
     }
 
-    @PostMapping(path = "/{task-id}/complete")
+    @ApiOperation("Completes a Task identified by an id.")
+    @ApiResponses({
+        @ApiResponse(
+            code = 204,
+            message = "No Content"
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 403,
+            message = "Forbidden"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @PostMapping(path = "/{task-id}/complete",
+        produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> completeTask(@PathVariable("task-id") String taskId) {
         throw new NotImplementedException();
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
@@ -189,9 +189,6 @@ public class TaskController {
     public ResponseEntity<String> assignTask(@PathVariable("task-id") String taskId,
                                              @RequestBody AssignTaskRequest assignTaskRequest) {
 
-        Objects.requireNonNull(assignTaskRequest);
-        Objects.requireNonNull(assignTaskRequest.getUserId());
-
         throw new NotImplementedException();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
@@ -19,8 +19,6 @@ import uk.gov.hmcts.reform.wataskmanagementapi.controllers.response.GetTasksResp
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CamundaService;
 
-import java.util.Objects;
-
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SuppressWarnings({

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.request;
+
+public class AssignTaskRequest {
+
+    private final String userId;
+
+    public AssignTaskRequest(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.controllers.request;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public class AssignTaskRequest {
 
     private final String userId;
 
+    @JsonCreator
     public AssignTaskRequest(String userId) {
         this.userId = userId;
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTaskResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTaskResponse.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.response;
+
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
+
+public class GetTaskResponse<T extends CamundaTask> {
+
+    private final T task;
+
+    public GetTaskResponse(T task) {
+        this.task = task;
+    }
+
+    public T getTask() {
+        return task;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.response;
+
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
+
+import java.util.List;
+
+public class GetTasksResponse<T extends CamundaTask> {
+
+    private final List<T> tasks;
+
+    public GetTasksResponse(List<T> tasks) {
+        this.tasks = tasks;
+    }
+
+    public List<T> getTasks() {
+        return tasks;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTask.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.domain.entities;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel("Task")
+public class CamundaTask {
+
+    private final String id;
+
+    public CamundaTask(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskControllerTest.java
@@ -8,16 +8,19 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.AssignTaskRequest;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.response.GetTaskResponse;
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CamundaService;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TaskControllerTest {
@@ -37,16 +40,13 @@ public class TaskControllerTest {
 
         String taskId = UUID.randomUUID().toString();
 
-        when(camundaService.getTask(taskId)).thenReturn("aTask");
-
-        ResponseEntity<String> response = taskController.getTask(taskId);
+        ResponseEntity<GetTaskResponse<CamundaTask>> response = taskController.getTask(taskId);
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertThat(
-            response.getBody(),
-            containsString("aTask")
-        );
+        assertThat(response.getBody(), instanceOf(GetTaskResponse.class));
+        assertEquals(Optional.ofNullable(response.getBody())
+                         .orElseThrow(AssertionError::new).getTask().getId(), taskId);
     }
 
     @Test
@@ -66,7 +66,10 @@ public class TaskControllerTest {
             .isInstanceOf(NotImplementedException.class)
             .hasMessage("Code is not implemented");
 
-        assertThatThrownBy(() -> taskController.assignTask(someTaskId))
+        assertThatThrownBy(() -> taskController.assignTask(
+            someTaskId,
+            new AssignTaskRequest("some-user")
+        ))
             .isInstanceOf(NotImplementedException.class)
             .hasMessage("Code is not implemented");
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/AssignTaskRequestTest.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.request;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssignTaskRequestTest {
+
+    @Test
+    void should_create_object_and_get_value() {
+
+        final AssignTaskRequest assignTaskRequest = new AssignTaskRequest("some-user");
+        assertThat(assignTaskRequest.getUserId()).isEqualTo("some-user");
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTaskResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTaskResponseTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class GetTaskResponseTest {
+
+    @Mock
+    private CamundaTask camundaTask;
+
+    @Test
+    void should_create_object_and_get_value() {
+
+        assertThat(camundaTask).isNotNull();
+        final GetTaskResponse<CamundaTask> camundaTaskGetTaskResponse =
+            new GetTaskResponse<>(camundaTask);
+        assertThat(camundaTaskGetTaskResponse.getTask()).isEqualTo(camundaTask);
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksResponseTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.controllers.response;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.CamundaTask;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class GetTasksResponseTest {
+
+    @Mock
+    private CamundaTask camundaTask;
+
+    @Test
+    void should_create_object_and_get_value() {
+
+        List<CamundaTask> camundaTasks = Lists.newArrayList(camundaTask);
+
+        final GetTasksResponse<CamundaTask> camundaTasksGetTaskResponse =
+            new GetTasksResponse<>(camundaTasks);
+
+        assertThat(camundaTasksGetTaskResponse.getTasks().size()).isEqualTo(1);
+        assertThat(camundaTasksGetTaskResponse.getTasks().get(0)).isEqualTo(camundaTask);
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTaskTest.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.domain.entities;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CamundaTaskTest {
+
+    @Test
+    void should_create_object_and_get_value() {
+        CamundaTask camundaTask = new CamundaTask("some-id");
+        Assertions.assertThat(camundaTask.getId()).isEqualTo("some-id");
+
+    }
+
+}


### PR DESCRIPTION
Adding initial Open API docs and some Skeleton entities to show the structure.

The Request structure for getting tasks with a criteria still needs to be done as do error message structures.