### PR TITLE
Suppress CVE-2020-13943

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,7 +10,7 @@
   </suppress>
   <suppress until="2030-01-01">
     <notes><![CDATA[
-     Suppressing as it's a false positive we are currently using apache tomcat 9.0.38
+     Suppressing as it's a false positive we are currently using apache tomcat 9.0.39
    ]]></notes>
     <cve>CVE-2020-13943</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,4 +8,10 @@
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>
+  <suppress until="2030-01-01">
+    <notes><![CDATA[
+     Suppressing as it's a false positive we are currently using apache tomcat 9.0.38
+   ]]></notes>
+    <cve>CVE-2020-13943</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Added CVE-2020-13943 to exceptions as the vulnerability applies to apache tomcat 9.0.37 and below but we are currently using 9.0.38

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
