### PR TITLE
Fix Camunda variables scope

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostClaimByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostClaimByIdControllerTest.java
@@ -99,7 +99,7 @@ public class PostClaimByIdControllerTest extends SpringBootFunctionalBaseTest {
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -120,7 +120,7 @@ public class PostClaimByIdControllerTest extends SpringBootFunctionalBaseTest {
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -141,7 +141,7 @@ public class PostClaimByIdControllerTest extends SpringBootFunctionalBaseTest {
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         Response resultAfterClaimedBySameUser = restApiActions.post(
             ENDPOINT_BEING_TESTED,
@@ -152,7 +152,7 @@ public class PostClaimByIdControllerTest extends SpringBootFunctionalBaseTest {
         resultAfterClaimedBySameUser.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -244,7 +244,7 @@ public class PostClaimByIdControllerTest extends SpringBootFunctionalBaseTest {
 
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskAssignByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskAssignByIdControllerTest.java
@@ -79,7 +79,7 @@ public class PostTaskAssignByIdControllerTest extends SpringBootFunctionalBaseTe
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -101,7 +101,7 @@ public class PostTaskAssignByIdControllerTest extends SpringBootFunctionalBaseTe
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "assigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "assigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskCompleteByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskCompleteByIdControllerTest.java
@@ -75,7 +75,7 @@ public class PostTaskCompleteByIdControllerTest extends SpringBootFunctionalBase
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "completed");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "completed");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -97,7 +97,7 @@ public class PostTaskCompleteByIdControllerTest extends SpringBootFunctionalBase
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "completed");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "completed");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
@@ -98,7 +98,7 @@ public class PostUnclaimByIdControllerTest extends SpringBootFunctionalBaseTest 
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "unassigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "unassigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }
@@ -119,7 +119,7 @@ public class PostUnclaimByIdControllerTest extends SpringBootFunctionalBaseTest 
         result.then().assertThat()
             .statusCode(HttpStatus.NO_CONTENT.value());
 
-        assertions.taskVariableWasUpdated(taskId, "taskState", "unassigned");
+        assertions.taskVariableWasUpdated(taskVariables.getProcessInstanceId(), "taskState", "unassigned");
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/clients/CamundaServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/clients/CamundaServiceApi.java
@@ -7,14 +7,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import uk.gov.hmcts.reform.wataskmanagementapi.config.CamundaFeignConfiguration;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.AddLocalVariableRequest;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaVariable;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CompleteTaskVariables;
-import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.HistoryVariableInstance;
 
 import java.util.List;
 import java.util.Map;
@@ -64,13 +62,6 @@ public interface CamundaServiceApi {
     void unclaimTask(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
                      @PathVariable("task-id") String id);
 
-    @GetMapping(
-        value = "/history/variable-instance",
-        produces = APPLICATION_JSON_VALUE
-    )
-    List<HistoryVariableInstance> getTaskVariables(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-                                                   @RequestParam("taskIdIn") String taskId);
-
     @PostMapping(
         value = "/task/{task-id}/complete",
         consumes = APPLICATION_JSON_VALUE,
@@ -81,7 +72,7 @@ public interface CamundaServiceApi {
                       CompleteTaskVariables variables);
 
     @PostMapping(
-        value = "/task/{id}/localVariables",
+        value = "/task/{id}/variables",
         consumes = APPLICATION_JSON_VALUE
     )
     void addLocalVariablesToTask(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
@@ -101,9 +92,9 @@ public interface CamundaServiceApi {
         value = "/decision-definition/key/{key}/tenant-id/ia/evaluate",
         consumes = APPLICATION_JSON_VALUE
     )
-    List<Map<String, CamundaVariable>>   evaluateDMN(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-                    @PathVariable("key") String key,
-                    @RequestBody Map<String,Map<String,CamundaVariable>> body);
+    List<Map<String, CamundaVariable>> evaluateDMN(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+                                                   @PathVariable("key") String key,
+                                                   @RequestBody Map<String, Map<String, CamundaVariable>> body);
 
 
     @GetMapping(
@@ -119,8 +110,8 @@ public interface CamundaServiceApi {
         consumes = APPLICATION_JSON_VALUE
     )
     void bpmnEscalation(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-                    @PathVariable("task-id") String id,
-                    @RequestBody Map<String, String> body);
+                        @PathVariable("task-id") String id,
+                        @RequestBody Map<String, String> body);
 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/camunda/CamundaTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/camunda/CamundaTask.java
@@ -23,6 +23,7 @@ public class CamundaTask {
     private String description;
     private String owner;
     private String formKey;
+    private String processInstanceId;
 
     private CamundaTask() {
         //Hidden constructor
@@ -36,7 +37,9 @@ public class CamundaTask {
                        ZonedDateTime due,
                        String description,
                        String owner,
-                       String formKey) {
+                       String formKey,
+                       String processInstanceId
+                       ) {
         this.id = id;
         this.name = name;
         this.assignee = assignee;
@@ -45,6 +48,7 @@ public class CamundaTask {
         this.description = description;
         this.owner = owner;
         this.formKey = formKey;
+        this.processInstanceId = processInstanceId;
     }
 
     public String getId() {
@@ -77,5 +81,9 @@ public class CamundaTask {
 
     public String getFormKey() {
         return formKey;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.services;
 
-import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +63,6 @@ public class CamundaService {
     private final AuthTokenGenerator authTokenGenerator;
     private final PermissionEvaluatorService permissionEvaluatorService;
     private final CamundaObjectMapper camundaObjectMapper;
-    private final Gson gson = new Gson();
 
     @Autowired
     public CamundaService(CamundaServiceApi camundaServiceApi,
@@ -224,7 +222,6 @@ public class CamundaService {
 
         CamundaSearchQuery query = camundaQueryBuilder.createQuery(searchTaskRequest);
 
-        log.info("Camunda search query: {}", gson.toJson(query.getQueries()));
         return performSearchAction(query, roleAssignments, permissionsRequired);
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -64,6 +64,7 @@ public class CamundaService {
     private final AuthTokenGenerator authTokenGenerator;
     private final PermissionEvaluatorService permissionEvaluatorService;
     private final CamundaObjectMapper camundaObjectMapper;
+    private final Gson gson = new Gson();
 
     @Autowired
     public CamundaService(CamundaServiceApi camundaServiceApi,
@@ -223,8 +224,7 @@ public class CamundaService {
 
         CamundaSearchQuery query = camundaQueryBuilder.createQuery(searchTaskRequest);
 
-        Gson g = new Gson();
-        log.info("Camunda search query: {}", g.toJson(query.getQueries()));
+        log.info("Camunda search query: {}", gson.toJson(query.getQueries()));
         return performSearchAction(query, roleAssignments, permissionsRequired);
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.services;
 
-import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +63,6 @@ public class CamundaService {
     private final AuthTokenGenerator authTokenGenerator;
     private final PermissionEvaluatorService permissionEvaluatorService;
     private final CamundaObjectMapper camundaObjectMapper;
-    private final Gson gson = new Gson();
 
     @Autowired
     public CamundaService(CamundaServiceApi camundaServiceApi,
@@ -224,7 +222,7 @@ public class CamundaService {
 
         CamundaSearchQuery query = camundaQueryBuilder.createQuery(searchTaskRequest);
 
-        log.info("Camunda search query: {}", gson.toJson(query.getQueries()));
+        log.info("Camunda search query: {}", query.getQueries());
         return performSearchAction(query, roleAssignments, permissionsRequired);
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.services;
 
+import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -222,7 +223,8 @@ public class CamundaService {
 
         CamundaSearchQuery query = camundaQueryBuilder.createQuery(searchTaskRequest);
 
-        log.info("Camunda search query: {}", query.getQueries());
+        Gson g = new Gson();
+        log.info("Camunda search query: {}", g.toJson(query.getQueries()));
         return performSearchAction(query, roleAssignments, permissionsRequired);
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/CamundaTaskTest.java
@@ -21,7 +21,8 @@ class CamundaTaskTest {
             dueDate,
             "some-description",
             "some-owner",
-            "formKey"
+            "formKey",
+            "processInstanceId"
         );
 
         Assertions.assertThat(camundaTask.getId()).isEqualTo("some-id");
@@ -32,5 +33,6 @@ class CamundaTaskTest {
         Assertions.assertThat(camundaTask.getDescription()).isEqualTo("some-description");
         Assertions.assertThat(camundaTask.getOwner()).isEqualTo("some-owner");
         Assertions.assertThat(camundaTask.getFormKey()).isEqualTo("formKey");
+        Assertions.assertThat(camundaTask.getProcessInstanceId()).isEqualTo("processInstanceId");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/utils/CreateTaskVariableTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/utils/CreateTaskVariableTest.java
@@ -29,7 +29,7 @@ class CreateTaskVariableTest {
 
         camundaTask = new CamundaTask("some-id", "some-name", "some-assignee",
             created, dueDate, "some-description",
-            "some-owner", "formKey"
+            "some-owner", "formKey", "processInstanceId"
         );
 
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaQueryBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaQueryBuilderTest.java
@@ -38,6 +38,103 @@ class CamundaQueryBuilderTest {
     }
 
     @Test
+    void createQuery_should_build_query_for_task_state_unassigned()
+        throws JsonProcessingException, JSONException {
+
+        SearchTaskRequest searchTaskRequest = new SearchTaskRequest(singletonList(
+            new SearchParameter(STATE, SearchOperator.IN, asList("unassigned"))
+        ));
+
+        CamundaSearchQuery camundaSearchQuery = camundaQueryBuilder.createQuery(searchTaskRequest);
+
+        String resultJson = objectMapper.writeValueAsString(camundaSearchQuery);
+
+        String expected = "{\n"
+                          + "  \"queries\": {\n"
+                          + "    \"orQueries\": [\n"
+                          + "      {\n"
+                          + "        \"processVariables\": [\n"
+                          + "          {\n"
+                          + "            \"name\": \"taskState\",\n"
+                          + "            \"operator\": \"eq\",\n"
+                          + "            \"value\": \"unassigned\"\n"
+                          + "          }\n"
+                          + "        ]\n"
+                          + "      }\n"
+                          + "    ]\n"
+                          + "  }\n"
+                          + "}\n";
+
+        JSONAssert.assertEquals(expected, resultJson, false);
+    }
+
+    @Test
+    void createQuery_should_build_query_for_task_state_assigned()
+        throws JsonProcessingException, JSONException {
+
+        SearchTaskRequest searchTaskRequest = new SearchTaskRequest(singletonList(
+            new SearchParameter(STATE, SearchOperator.IN, asList("assigned"))
+        ));
+
+        CamundaSearchQuery camundaSearchQuery = camundaQueryBuilder.createQuery(searchTaskRequest);
+
+        String resultJson = objectMapper.writeValueAsString(camundaSearchQuery);
+        String expected = "{\n"
+                          + "  \"queries\": {\n"
+                          + "    \"orQueries\": [\n"
+                          + "      {\n"
+                          + "        \"processVariables\": [\n"
+                          + "          {\n"
+                          + "            \"name\": \"taskState\",\n"
+                          + "            \"operator\": \"eq\",\n"
+                          + "            \"value\": \"assigned\"\n"
+                          + "          }\n"
+                          + "        ]\n"
+                          + "      }\n"
+                          + "    ]\n"
+                          + "  }\n"
+                          + "}\n";
+
+        JSONAssert.assertEquals(expected, resultJson, false);
+    }
+
+    @Test
+    void createQuery_should_build_query_for_task_state_assigned_and_unassigned()
+        throws JsonProcessingException, JSONException {
+
+        SearchTaskRequest searchTaskRequest = new SearchTaskRequest(singletonList(
+            new SearchParameter(STATE, SearchOperator.IN, asList("assigned", "unassigned"))
+        ));
+
+        CamundaSearchQuery camundaSearchQuery = camundaQueryBuilder.createQuery(searchTaskRequest);
+
+        String resultJson = objectMapper.writeValueAsString(camundaSearchQuery);
+
+        String expected = "{\n"
+                          + "  \"queries\": {\n"
+                          + "    \"orQueries\": [\n"
+                          + "      {\n"
+                          + "        \"processVariables\": [\n"
+                          + "          {\n"
+                          + "            \"name\": \"taskState\",\n"
+                          + "            \"operator\": \"eq\",\n"
+                          + "            \"value\": \"assigned\"\n"
+                          + "          },\n"
+                          + "          {\n"
+                          + "            \"name\": \"taskState\",\n"
+                          + "            \"operator\": \"eq\",\n"
+                          + "            \"value\": \"unassigned\"\n"
+                          + "          }\n"
+                          + "        ]\n"
+                          + "      }\n"
+                          + "    ]\n"
+                          + "  }\n"
+                          + "}\n";
+
+        JSONAssert.assertEquals(expected, resultJson, false);
+    }
+
+    @Test
     void createQuery_should_build_query_from_search_task_request_with_OR_and_AND_queries()
         throws JsonProcessingException, JSONException {
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
@@ -97,7 +97,8 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
             ZonedDateTime.now().plusDays(1),
             "someCamundaTaskDescription",
             "someCamundaTaskOwner",
-            "someCamundaTaskFormKey"
+            "someCamundaTaskFormKey",
+            "someProcessInstanceId"
         );
     }
 
@@ -246,7 +247,8 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
                 dueDate,
                 null,
                 null,
-                "someFormKey"
+                "someFormKey",
+                "someProcessInstanceId"
             );
 
             Map<String, CamundaVariable> variables = mockVariables();
@@ -307,7 +309,8 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
                 dueDate,
                 null,
                 null,
-                "someFormKey"
+                "someFormKey",
+                "someProcessInstanceId"
             );
 
             Map<String, CamundaVariable> variables = mockVariables();
@@ -944,7 +947,8 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
                 dueDate,
                 null,
                 null,
-                "someFormKey"
+                "someFormKey",
+                "someProcessInstanceId"
             );
 
             Map<String, CamundaVariable> variables = mockVariables();
@@ -1011,7 +1015,8 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
                 dueDate,
                 null,
                 null,
-                "someFormKey"
+                "someFormKey",
+                "someProcessInstanceId"
             );
 
             Map<String, CamundaVariable> variables = mockVariables();

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskMapperTest.java
@@ -39,7 +39,8 @@ class TaskMapperTest {
             dueDate,
             null,
             null,
-            "some-key"
+            "some-key",
+            "someProcessInstanceId"
         );
 
         Map<String, CamundaVariable> variables = new HashMap<>();
@@ -78,7 +79,8 @@ class TaskMapperTest {
             dueDate,
             null,
             null,
-            "some-key"
+            "some-key",
+            "someProcessInstanceId"
         );
 
         Task result = taskMapper.mapToTaskObject(new HashMap<String, CamundaVariable>(), camundaTask);
@@ -103,7 +105,8 @@ class TaskMapperTest {
             dueDate,
             null,
             null,
-            "some-key"
+            "some-key",
+            "someProcessInstanceId"
         );
 
         Map<String, CamundaVariable> variables = new HashMap<>();
@@ -140,7 +143,8 @@ class TaskMapperTest {
             dueDate,
             null,
             null,
-            "some-key"
+            "some-key",
+            "someProcessInstanceId"
         );
 
         Map<String, CamundaVariable> variables = new HashMap<>();

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/TestVariables.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/TestVariables.java
@@ -11,12 +11,15 @@ public class TestVariables {
 
     private final String caseId;
     private final String taskId;
+    private final String processInstanceId;
 
-    public TestVariables(String caseId, String taskId) {
+    public TestVariables(String caseId, String taskId, String processInstanceId) {
         Objects.requireNonNull(caseId, "caseId must not be null");
         Objects.requireNonNull(taskId, "taskId must not be null");
+        Objects.requireNonNull(processInstanceId, "processInstanceId must not be null");
         this.caseId = caseId;
         this.taskId = taskId;
+        this.processInstanceId = processInstanceId;
     }
 
     public String getCaseId() {
@@ -25,5 +28,9 @@ public class TestVariables {
 
     public String getTaskId() {
         return taskId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
     }
 }

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Assertions.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Assertions.java
@@ -23,10 +23,10 @@ public class Assertions {
         this.authorizationHeadersProvider = authorizationHeadersProvider;
     }
 
-    public void taskVariableWasUpdated(String taskId, String variable, String value) {
+    public void taskVariableWasUpdated(String processInstanceId, String variable, String value) {
 
         Response result = camundaApiActions.get(
-            "/history/variable-instance?taskIdIn=" + taskId,
+            "/history/variable-instance?processInstanceId=" + processInstanceId,
             authorizationHeadersProvider.getServiceAuthorizationHeader()
         );
 

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Common.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Common.java
@@ -85,7 +85,7 @@ public class Common {
             fail("Search was not an exact match and returned more than one task used: " + caseId);
         }
 
-        return new TestVariables(caseId, response.get(0).getId());
+        return new TestVariables(caseId, response.get(0).getId(), response.get(0).getProcessInstanceId());
 
     }
 
@@ -123,7 +123,7 @@ public class Common {
             fail("Search was not an exact match and returned more than one task used: " + caseId);
         }
 
-        return new TestVariables(caseId, response.get(0).getId());
+        return new TestVariables(caseId, response.get(0).getId(), response.get(0).getProcessInstanceId());
     }
 
     public TestVariables setupTaskAndRetrieveIds() {
@@ -139,7 +139,7 @@ public class Common {
             fail("Search was not an exact match and returned more than one task used: " + caseId);
         }
 
-        return new TestVariables(caseId, response.get(0).getId());
+        return new TestVariables(caseId, response.get(0).getId(), response.get(0).getProcessInstanceId());
     }
 
     public void cleanUpTask(String taskId, String reason) {


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Fix Camunda variables scope.
Calling the localVariables creates a new variable as the task state causing an issue where camunda tasks would have 2 task states instead of updating the original one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
