### PR TITLE
RWA-458: Conditional checks based on roles on unclaim endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ This will do compilation, checkstyle, PMD checks , run tests , but not integrati
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
@@ -54,7 +54,7 @@ public class PostUnclaimByIdControllerTest extends SpringBootFunctionalBaseTest 
             .body("error", equalTo(HttpStatus.NOT_FOUND.getReasonPhrase()))
             .body("status", equalTo(HttpStatus.NOT_FOUND.value()))
             .body("message", equalTo(String.format(
-                "There was a problem fetching the variables for task with id: %s",
+                "There was a problem fetching the task with id: %s",
                 nonExistentTaskId
             )));
     }
@@ -149,7 +149,8 @@ public class PostUnclaimByIdControllerTest extends SpringBootFunctionalBaseTest 
                 .format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT))))
             .body("error", equalTo(HttpStatus.FORBIDDEN.getReasonPhrase()))
             .body("status", equalTo(HttpStatus.FORBIDDEN.value()))
-            .body("message", equalTo("Task was not claimed by this user"));
+            .body("message", equalTo(String.format(
+                "User did not have sufficient permissions to unclaim task with id: %s", taskId)));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
@@ -125,14 +125,44 @@ public class PostUnclaimByIdControllerTest extends SpringBootFunctionalBaseTest 
     }
 
     @Test
-    public void should_return_a_204_when_unclaiming_a_task_by_id_with_different_credentials() {
+    public void should_return_a_403_when_unclaiming_a_task_by_id_with_different_tribunal_caseworker_credentials() {
+        TestVariables taskVariables = common.setupTaskAndRetrieveIdsWithCustomVariable(ASSIGNEE, "random_uid");
+        String taskId = taskVariables.getTaskId();
+
+        Headers otherUserAuthenticationHeaders = authorizationHeadersProvider.getTribunalCaseworkerBAuthorization();
+        common.setupOrganisationalRoleAssignment(authenticationHeaders);
+        common.setupOrganisationalRoleAssignment(otherUserAuthenticationHeaders, "tribunal-caseworker");
+        given.iClaimATaskWithIdAndAuthorization(
+            taskId,
+            authenticationHeaders
+        );
+        Response result = restApiActions.post(
+            ENDPOINT_BEING_TESTED,
+            taskId,
+            otherUserAuthenticationHeaders
+        );
+
+        result.then().assertThat()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .contentType(APPLICATION_JSON_VALUE)
+            .body("timestamp", lessThanOrEqualTo(LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT))))
+            .body("error", equalTo(HttpStatus.FORBIDDEN.getReasonPhrase()))
+            .body("status", equalTo(HttpStatus.FORBIDDEN.value()))
+            .body("message", equalTo("Task was not claimed by this user"));
+
+        common.cleanUpTask(taskId, REASON_COMPLETED);
+    }
+
+    @Test
+    public void should_return_a_204_when_unclaiming_a_task_by_id_with_different_senior_tcw_credentials() {
         TestVariables taskVariables = common.setupTaskAndRetrieveIdsWithCustomVariable(ASSIGNEE, "random_uid");
         String taskId = taskVariables.getTaskId();
 
         Headers otherUserAuthenticationHeaders = authorizationHeadersProvider.getTribunalCaseworkerBAuthorization();
 
         common.setupOrganisationalRoleAssignment(authenticationHeaders);
-        common.setupOrganisationalRoleAssignment(otherUserAuthenticationHeaders);
+        common.setupOrganisationalRoleAssignment(otherUserAuthenticationHeaders, "senior-tribunal-caseworker");
 
         given.iClaimATaskWithIdAndAuthorization(
             taskId,

--- a/src/functionalTest/resources/requests/roleAssignment/set-organisational-role-assignment-request.json
+++ b/src/functionalTest/resources/requests/roleAssignment/set-organisational-role-assignment-request.json
@@ -7,7 +7,7 @@
       "grantType": "STANDARD",
       "readOnly": false,
       "roleCategory": "LEGAL_OPERATIONS",
-      "roleName": "tribunal-caseworker",
+      "roleName": "{ROLE_NAME_PLACEHOLDER}",
       "roleType": "ORGANISATION",
       "attributes": "{ATTRIBUTES_PLACEHOLDER}"
     }

--- a/src/functionalTest/resources/requests/roleAssignment/set-restricted-role-assignment-request.json
+++ b/src/functionalTest/resources/requests/roleAssignment/set-restricted-role-assignment-request.json
@@ -7,7 +7,7 @@
       "grantType": "SPECIFIC",
       "readOnly": false,
       "roleCategory": "LEGAL_OPERATIONS",
-      "roleName": "tribunal-caseworker",
+      "roleName": "{ROLE_NAME_PLACEHOLDER}",
       "roleType": "CASE",
       "attributes": {
         "caseId": "{CASE_ID_PLACEHOLDER}"

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/AttributesValueVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/AttributesValueVerifier.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.auth.permission;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaObjectMapper;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaVariable;
 
@@ -12,10 +14,12 @@ import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.Ca
 import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaVariableDefinition.LOCATION;
 import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaVariableDefinition.REGION;
 
+@Service
 public class AttributesValueVerifier {
 
     private final CamundaObjectMapper camundaObjectMapper;
 
+    @Autowired
     protected AttributesValueVerifier(CamundaObjectMapper camundaObjectMapper) {
         this.camundaObjectMapper = camundaObjectMapper;
     }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
@@ -50,9 +50,87 @@ class PermissionEvaluatorServiceTest {
 
     private Map<String, CamundaVariable> defaultVariables;
 
+    private static Stream<EndTimeScenario> endTimeScenarioProvider() {
+
+        EndTimeScenario endTimeIsNull = EndTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenEndTime(null))
+            .expectedHasAccess(true)
+            .build();
+
+        EndTimeScenario endTimeIsAfterCurrentTime = EndTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenEndTime(LocalDateTime.now().minusDays(3)))
+            .expectedHasAccess(false)
+            .build();
+
+        EndTimeScenario endTimeIsBeforeCurrentTime = EndTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenEndTime(LocalDateTime.now().plusDays(3)))
+            .expectedHasAccess(true)
+            .build();
+
+        return Stream.of(
+            endTimeIsNull,
+            endTimeIsAfterCurrentTime,
+            endTimeIsBeforeCurrentTime
+        );
+    }
+
+    private static Assignment buildRoleAssignmentGivenEndTime(LocalDateTime endTime) {
+        return Assignment.builder()
+            .actorIdType(ActorIdType.IDAM)
+            .actorId("some actor id")
+            .roleType(RoleType.ORGANISATION)
+            .roleName("tribunal-caseworker")
+            .classification(Classification.PUBLIC)
+            .grantType(GrantType.SPECIFIC)
+            .roleCategory(RoleCategory.LEGAL_OPERATIONS)
+            .endTime(endTime)
+            .build();
+    }
+
+    private static Stream<BeginTimeScenario> beginTimeScenarioProvider() {
+
+        BeginTimeScenario beginTimeIsNull = BeginTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenBeginTime(null))
+            .expectedHasAccess(true)
+            .build();
+
+        BeginTimeScenario beginTimeIsAfterCurrentTime = BeginTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenBeginTime(LocalDateTime.now().minusDays(3)))
+            .expectedHasAccess(true)
+            .build();
+
+        BeginTimeScenario beginTimeIsBeforeCurrentTime = BeginTimeScenario.builder()
+            .roleAssignment(buildRoleAssignmentGivenBeginTime(LocalDateTime.now().plusDays(3)))
+            .expectedHasAccess(false)
+            .build();
+
+        return Stream.of(
+            beginTimeIsNull,
+            beginTimeIsAfterCurrentTime,
+            beginTimeIsBeforeCurrentTime
+        );
+    }
+
+    private static Assignment buildRoleAssignmentGivenBeginTime(LocalDateTime beginTime) {
+        return Assignment.builder()
+            .actorIdType(ActorIdType.IDAM)
+            .actorId("some actor id")
+            .roleType(RoleType.ORGANISATION)
+            .roleName("tribunal-caseworker")
+            .classification(Classification.PUBLIC)
+            .grantType(GrantType.SPECIFIC)
+            .roleCategory(RoleCategory.LEGAL_OPERATIONS)
+            .beginTime(beginTime)
+            .build();
+    }
+
     @BeforeEach
     public void setUp() {
-        permissionEvaluatorService = new PermissionEvaluatorService(new CamundaObjectMapper());
+        CamundaObjectMapper camundaObjectMapper = new CamundaObjectMapper();
+        permissionEvaluatorService = new PermissionEvaluatorService(
+            camundaObjectMapper,
+            new AttributesValueVerifier(camundaObjectMapper)
+        );
         defaultVariables = getDefaultVariables();
     }
 
@@ -357,49 +435,6 @@ class PermissionEvaluatorServiceTest {
         assertEquals(scenario.expectedHasAccess, actualHasAccess);
     }
 
-    private static Stream<EndTimeScenario> endTimeScenarioProvider() {
-
-        EndTimeScenario endTimeIsNull = EndTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenEndTime(null))
-            .expectedHasAccess(true)
-            .build();
-
-        EndTimeScenario endTimeIsAfterCurrentTime = EndTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenEndTime(LocalDateTime.now().minusDays(3)))
-            .expectedHasAccess(false)
-            .build();
-
-        EndTimeScenario endTimeIsBeforeCurrentTime = EndTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenEndTime(LocalDateTime.now().plusDays(3)))
-            .expectedHasAccess(true)
-            .build();
-
-        return Stream.of(
-            endTimeIsNull,
-            endTimeIsAfterCurrentTime,
-            endTimeIsBeforeCurrentTime
-        );
-    }
-
-    private static Assignment buildRoleAssignmentGivenEndTime(LocalDateTime endTime) {
-        return Assignment.builder()
-            .actorIdType(ActorIdType.IDAM)
-            .actorId("some actor id")
-            .roleType(RoleType.ORGANISATION)
-            .roleName("tribunal-caseworker")
-            .classification(Classification.PUBLIC)
-            .grantType(GrantType.SPECIFIC)
-            .roleCategory(RoleCategory.LEGAL_OPERATIONS)
-            .endTime(endTime)
-            .build();
-    }
-
-    @Builder
-    private static class EndTimeScenario {
-        Assignment roleAssignment;
-        boolean expectedHasAccess;
-    }
-
     @ParameterizedTest
     @MethodSource("beginTimeScenarioProvider")
     void hasAccess_should_succeed_when_looking_for_begin_time_permission_and_return_true(
@@ -414,49 +449,6 @@ class PermissionEvaluatorServiceTest {
         );
 
         assertEquals(scenario.expectedHasAccess, actualHasAccess);
-    }
-
-    private static Stream<BeginTimeScenario> beginTimeScenarioProvider() {
-
-        BeginTimeScenario beginTimeIsNull = BeginTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenBeginTime(null))
-            .expectedHasAccess(true)
-            .build();
-
-        BeginTimeScenario beginTimeIsAfterCurrentTime = BeginTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenBeginTime(LocalDateTime.now().minusDays(3)))
-            .expectedHasAccess(true)
-            .build();
-
-        BeginTimeScenario beginTimeIsBeforeCurrentTime = BeginTimeScenario.builder()
-            .roleAssignment(buildRoleAssignmentGivenBeginTime(LocalDateTime.now().plusDays(3)))
-            .expectedHasAccess(false)
-            .build();
-
-        return Stream.of(
-            beginTimeIsNull,
-            beginTimeIsAfterCurrentTime,
-            beginTimeIsBeforeCurrentTime
-        );
-    }
-
-    private static Assignment buildRoleAssignmentGivenBeginTime(LocalDateTime beginTime) {
-        return Assignment.builder()
-            .actorIdType(ActorIdType.IDAM)
-            .actorId("some actor id")
-            .roleType(RoleType.ORGANISATION)
-            .roleName("tribunal-caseworker")
-            .classification(Classification.PUBLIC)
-            .grantType(GrantType.SPECIFIC)
-            .roleCategory(RoleCategory.LEGAL_OPERATIONS)
-            .beginTime(beginTime)
-            .build();
-    }
-
-    @Builder
-    private static class BeginTimeScenario {
-        Assignment roleAssignment;
-        boolean expectedHasAccess;
     }
 
     @Test
@@ -543,7 +535,6 @@ class PermissionEvaluatorServiceTest {
         });
     }
 
-
     @Test
     void hasAccess_should_succeed_when_looking_for_region_permission_and_return_true() {
 
@@ -585,7 +576,6 @@ class PermissionEvaluatorServiceTest {
             assertFalse(result);
         });
     }
-
 
     @Test
     void hasAccess_should_succeed_when_looking_for_location_permission_and_return_true() {
@@ -731,6 +721,18 @@ class PermissionEvaluatorServiceTest {
         );
 
         return variables;
+    }
+
+    @Builder
+    private static class EndTimeScenario {
+        Assignment roleAssignment;
+        boolean expectedHasAccess;
+    }
+
+    @Builder
+    private static class BeginTimeScenario {
+        Assignment roleAssignment;
+        boolean expectedHasAccess;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
@@ -135,6 +135,76 @@ class PermissionEvaluatorServiceTest {
     }
 
     @Test
+    void hasAccessWithUserIdAssigneeCheck_should_succeed_senior_tribunal_case_worker() {
+
+        List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);
+
+        List<Assignment> testCases = createTestAssignments(
+            singletonList("senior-tribunal-caseworker"),
+            Classification.PUBLIC,
+            emptyMap()
+        );
+
+        testCases.forEach(roleAssignment -> {
+            boolean result = permissionEvaluatorService.hasAccessWithUserIdAssigneeCheck(
+                null,
+                "someUserId",
+                defaultVariables,
+                singletonList(roleAssignment),
+                permissionsRequired
+            );
+            assertTrue(result);
+        });
+    }
+
+    @Test
+    void hasAccessWithUserIdAssigneeCheck_should_succeed_tribunal_case_worker_assigned_to_task() {
+
+        List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);
+
+        List<Assignment> testCases = createTestAssignments(
+            singletonList("tribunal-caseworker"),
+            Classification.PUBLIC,
+            emptyMap()
+        );
+
+        testCases.forEach(roleAssignment -> {
+            boolean result = permissionEvaluatorService.hasAccessWithUserIdAssigneeCheck(
+                "someUserId",
+                "someUserId",
+                defaultVariables,
+                singletonList(roleAssignment),
+                permissionsRequired
+            );
+            assertTrue(result);
+        });
+    }
+
+
+    @Test
+    void hasAccessWithUserIdAssigneeCheck_should_fail_different_tribunal_case_worker_assigned_to_task() {
+
+        List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);
+
+        List<Assignment> testCases = createTestAssignments(
+            singletonList("tribunal-caseworker"),
+            Classification.PUBLIC,
+            emptyMap()
+        );
+
+        testCases.forEach(roleAssignment -> {
+            boolean result = permissionEvaluatorService.hasAccessWithUserIdAssigneeCheck(
+                "anotherUserId",
+                "someUserId",
+                defaultVariables,
+                singletonList(roleAssignment),
+                permissionsRequired
+            );
+            assertFalse(result);
+        });
+    }
+
+    @Test
     void hasAccess_should_succeed_when_looking_for_read_permission_and_return_true() {
 
         List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);
@@ -670,7 +740,7 @@ class PermissionEvaluatorServiceTest {
             .forEach(roleType -> {
                     Assignment roleAssignment = createBaseAssignment(
                         UUID.randomUUID().toString(),
-                        "tribunal-caseworker",
+                        roleName,
                         roleType,
                         roleClassification,
                         roleAttributes

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/permission/PermissionEvaluatorServiceTest.java
@@ -158,6 +158,29 @@ class PermissionEvaluatorServiceTest {
     }
 
     @Test
+    void hasAccessWithUserIdAssigneeCheck_should_succeed_senior_tribunal_case_worker_another_user_assigned() {
+
+        List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);
+
+        List<Assignment> testCases = createTestAssignments(
+            singletonList("senior-tribunal-caseworker"),
+            Classification.PUBLIC,
+            emptyMap()
+        );
+
+        testCases.forEach(roleAssignment -> {
+            boolean result = permissionEvaluatorService.hasAccessWithUserIdAssigneeCheck(
+                "anotherUserId",
+                "someUserId",
+                defaultVariables,
+                singletonList(roleAssignment),
+                permissionsRequired
+            );
+            assertTrue(result);
+        });
+    }
+
+    @Test
     void hasAccessWithUserIdAssigneeCheck_should_succeed_tribunal_case_worker_assigned_to_task() {
 
         List<PermissionTypes> permissionsRequired = singletonList(PermissionTypes.READ);

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
@@ -272,7 +272,6 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
             List<Assignment> roleAssignment = singletonList(mock(Assignment.class));
             UserInfo userInfoMock = mock(UserInfo.class);
             String someAssignee = "someAssignee";
-            when(userInfoMock.getUid()).thenReturn(someAssignee);
             AccessControlResponse accessControlResponse = new AccessControlResponse(userInfoMock, roleAssignment);
             List<PermissionTypes> permissionsRequired = singletonList(READ);
             SearchTaskRequest searchTaskRequest = mock(SearchTaskRequest.class);
@@ -298,6 +297,12 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
                 BEARER_SERVICE_TOKEN,
                 Map.of("variableScopeIdIn", singletonList("someProcessInstanceId"))
             )).thenReturn(mockedVariablesResponse("someProcessInstanceId"));
+
+            when(permissionEvaluatorService.hasAccess(
+                anyMap(),
+                eq(accessControlResponse.getRoleAssignments()),
+                eq(permissionsRequired)
+            )).thenReturn(true);
 
             List<Task> results = camundaService.searchWithCriteria(
                 searchTaskRequest,
@@ -363,7 +368,7 @@ class CamundaServiceTest extends CamundaServiceBaseTest {
 
             when(permissionEvaluatorService.hasAccess(
                 anyMap(),
-                eq(roleAssignment),
+                eq(accessControlResponse.getRoleAssignments()),
                 eq(permissionsRequired)
             )).thenReturn(true);
 

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/SpringBootFunctionalBaseTest.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/SpringBootFunctionalBaseTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
-import uk.gov.hmcts.reform.wataskmanagementapi.clients.IdamWebApi;
+import uk.gov.hmcts.reform.wataskmanagementapi.auth.idam.IdamService;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.RoleAssignmentServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.config.GivensBuilder;
 import uk.gov.hmcts.reform.wataskmanagementapi.config.RestApiActions;
@@ -39,7 +39,7 @@ public abstract class SpringBootFunctionalBaseTest {
     protected CoreCaseDataApi coreCaseDataApi;
 
     @Autowired
-    protected IdamWebApi idamWebApi;
+    protected IdamService idamService;
 
     @Autowired
     protected RoleAssignmentServiceApi roleAssignmentServiceApi;
@@ -64,7 +64,7 @@ public abstract class SpringBootFunctionalBaseTest {
             given,
             camundaApiActions,
             authorizationHeadersProvider,
-            idamWebApi,
+            idamService,
             roleAssignmentServiceApi
         );
 


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

Changes to logic to allow checks for userId when roles are tribunal-caseworkers on unclaim endpoint
Remove direct use of IdamWebApi to use cache in ft tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
