### PR TITLE
RWA-463: Performance Improvement: Make idam use the api url directly 

### DIFF
--- a/src/contractTest/resources/application.properties
+++ b/src/contractTest/resources/application.properties
@@ -1,4 +1,5 @@
 idam.baseUrl=http://localhost:8892
+idam.api.baseUrl=http://localhost:8892
 idam.redirectUrl=${IA_IDAM_REDIRECT_URI:http://localhost:8892/oauth2/callback}
 idam.scope="openid profile roles"
 idam.s2s-auth.url=${S2S_URL:http://127.0.0.1:4502}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/clients/IdamWebApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/clients/IdamWebApi.java
@@ -17,7 +17,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @FeignClient(
     name = "idam-web-api",
-    url = "${idam.baseUrl}",
+    url = "${idam.api.baseUrl}",
     configuration = FeignConfiguration.class
 )
 public interface IdamWebApi {


### PR DESCRIPTION

### JIRA link (if applicable) ###

I noticed we sometimes call idam endpoints through the idam-web-public url this is wrong and we should call those endpoints through the idam api instead. 

The reason for this is that it seems that if you call the web public url it proxies your request into the api making 2 calls with 400 ms  delay. 

We could avoid that second call by calling the idam-api directly and cut the time the request takes by half.

### Change description ###

https://tools.hmcts.net/jira/browse/RWA-463

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
