### PR TITLE
RWA-556: Complete the Event without an associated task

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchForCompletableConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchForCompletableConsumerTest.java
@@ -67,7 +67,7 @@ public class TaskManagementGetTasksBySearchForCompletableConsumerTest extends Sp
     private DslPart createResponseForGetTask() {
         return newJsonBody(
             o -> o
-            .booleanValue("task_required_for_event", false)
+            .booleanType("task_required_for_event", false)
             .minArrayLike("tasks", 1, 1,
                     task -> task
                        .stringType("id", "4d4b6fgh-c91f-433f-92ac-e456ae34f72a")

--- a/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchForCompletableConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchForCompletableConsumerTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.wataskmanagementapi.consumer.wa;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.google.common.collect.ImmutableMap;
+import io.restassured.http.ContentType;
+import net.serenitybdd.rest.SerenityRest;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import uk.gov.hmcts.reform.wataskmanagementapi.SpringBootContractBaseTest;
+import uk.gov.hmcts.reform.wataskmanagementapi.provider.service.CamundaConsumerApplication;
+import uk.gov.hmcts.reform.wataskmanagementapi.provider.service.TaskManagementProviderTestConfiguration;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static io.pactfoundation.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@PactTestFor(providerName = "wa_task_management_api_search_completable", port = "8991")
+@ContextConfiguration(classes = {CamundaConsumerApplication.class})
+@Import(TaskManagementProviderTestConfiguration.class)
+public class TaskManagementGetTasksBySearchForCompletableConsumerTest extends SpringBootContractBaseTest {
+
+    public static final String CONTENT_TYPE = "Content-Type";
+    private static final String WA_URL = "/task";
+    private static final String WA_SEARCH_FOR_COMPLETABLE = WA_URL + "/search-for-completable";
+
+    @Test
+    @PactTestFor(pactMethod = "executeSearchForCompletable200")
+    void testSearchForCompletable200Test(MockServer mockServer) throws IOException {
+        SerenityRest
+            .given()
+            .headers(getHttpHeaders())
+            .contentType(ContentType.JSON)
+            .body(creteSearchEventCaseRequest())
+            .post(mockServer.getUrl() + WA_SEARCH_FOR_COMPLETABLE)
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Pact(provider = "wa_task_management_api_search_completable", consumer = "wa_task_management_api")
+    public RequestResponsePact executeSearchForCompletable200(PactDslWithProvider builder) {
+        return builder
+            .given("appropriate tasks are returned by search for completable")
+            .uponReceiving("Provider receives a POST /task/search-for-completable request from a WA API")
+            .path(WA_SEARCH_FOR_COMPLETABLE)
+            .method(HttpMethod.POST.toString())
+            .headers(getTaskManagementServiceResponseHeaders())
+            .matchHeader(AUTHORIZATION, AUTH_TOKEN)
+            .matchHeader(SERVICE_AUTHORIZATION, SERVICE_AUTH_TOKEN)
+            .body(creteSearchEventCaseRequest(), String.valueOf(ContentType.JSON))
+            .willRespondWith()
+            .status(HttpStatus.OK.value())
+            .body(createResponseForGetTask())
+            .toPact();
+    }
+
+    private DslPart createResponseForGetTask() {
+        return newJsonBody(
+            o -> o
+            .booleanValue("task_required_for_event", false)
+            .minArrayLike("tasks", 1, 1,
+                    task -> task
+                       .stringType("id", "4d4b6fgh-c91f-433f-92ac-e456ae34f72a")
+                       .stringType("name", "Review the appeal")
+                       .stringType("assignee", "10bac6bf-80a7-4c81-b2db-516aba826be6")
+                       .stringType("type", "ReviewTheAppeal")
+                       .stringType("task_state", "assigned")
+                       .stringType("task_system", "SELF")
+                       .stringType("security_classification", "PUBLIC")
+                       .stringType("task_title", "Review the appeal")
+                       .datetime("due_date", "yyyy-MM-dd'T'HH:mm:ssZ")
+                       .datetime("created_date", "yyyy-MM-dd'T'HH:mm:ssZ")
+                       .stringType("location_name", "Taylor House")
+                       .stringType("location", "765324")
+                       .stringType("execution_type", "Case Management Task")
+                       .stringType("jurisdiction", "IA")
+                       .stringType("region", "1")
+                       .stringType("case_type_id", "Asylum")
+                       .stringType("case_id", "1617708245335311")
+                       .stringType("case_category", "refusalOfHumanRights")
+                       .stringType("case_name", "Bob Smith")
+                       .booleanType("auto_assigned", true)
+                       .booleanType("warnings", true)
+            )).build();
+    }
+
+    private Map<String, String> getTaskManagementServiceResponseHeaders() {
+        return ImmutableMap.<String, String>builder()
+            .put(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+            .put(SERVICE_AUTHORIZATION, SERVICE_AUTH_TOKEN)
+            .put(AUTHORIZATION, AUTH_TOKEN)
+            .build();
+    }
+
+    private String creteSearchEventCaseRequest() {
+        String request = "";
+        request = "{\n"
+            + "    \"case_id\": \"14a21569-eb80-4681-b62c-6ae2ed069e4f\",\n"
+            + "    \"event_id\": \"requestRespondentEvidence\",\n"
+            + "    \"case_jurisdiction\": \"IA\",\n"
+            + "    \"case_type\": \"Asylum\",\n"
+            + "  }\n";
+        return request;
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/provider/TaskManagementGetTaskBySearchForCompletablePactTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/provider/TaskManagementGetTaskBySearchForCompletablePactTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.wataskmanagementapi.auth.access.AccessControlService;
 import uk.gov.hmcts.reform.wataskmanagementapi.auth.access.entities.AccessControlResponse;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.TaskSearchController;
+import uk.gov.hmcts.reform.wataskmanagementapi.controllers.response.GetTasksCompletableResponse;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.task.Task;
 import uk.gov.hmcts.reform.wataskmanagementapi.provider.service.TaskManagementProviderTestConfiguration;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CamundaService;
@@ -113,7 +114,8 @@ public class TaskManagementGetTaskBySearchForCompletablePactTest {
     private void setInitMockForSearchByCompletableTask() {
         AccessControlResponse accessControlResponse = mock((AccessControlResponse.class));
         when(accessControlService.getRoles(anyString())).thenReturn(accessControlResponse);
-        when(camundaService.searchForCompletableTasks(any(), any(), any())).thenReturn(createTasks());
+        when(camundaService.searchForCompletableTasks(any(), any(), any()))
+            .thenReturn(new GetTasksCompletableResponse<>(false, createTasks()));
     }
 
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskForSearchCompletionControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskForSearchCompletionControllerTest.java
@@ -110,6 +110,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(false))
             .body("tasks.size()", equalTo(0));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
@@ -150,6 +151,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(true))
             .body("tasks.size()", equalTo(1))
             .body("tasks[0].id", equalTo(taskId2));
 
@@ -184,6 +186,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(true))
             .body("tasks.size()", equalTo(1))
             .body("tasks[0].task_state", equalTo("unassigned"))
             .body("tasks[0].case_id", equalTo(taskVariables.getCaseId()))
@@ -235,6 +238,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(true))
             .body("tasks.size()", equalTo(1))
             .body("tasks[0].task_state", equalTo("assigned"))
             .body("tasks[0].case_id", equalTo(caseId))
@@ -296,6 +300,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(true))
             .body("tasks.size()", equalTo(2))
             .body("tasks.id", hasItems(taskId2, taskId3))
             .body("tasks.case_id", everyItem(is(caseId)))
@@ -327,6 +332,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(false))
             .body("tasks.size()", equalTo(0));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
@@ -377,6 +383,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(false))
             .body("tasks.size()", equalTo(0));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
@@ -401,6 +408,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(false))
             .body("tasks.size()", equalTo(0));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);
@@ -432,6 +440,7 @@ public class PostTaskForSearchCompletionControllerTest extends SpringBootFunctio
         result.then().assertThat()
             .statusCode(HttpStatus.OK.value())
             .contentType(APPLICATION_JSON_VALUE)
+            .body("task_required_for_event ", is(false))
             .body("tasks.size()", equalTo(0));
 
         common.cleanUpTask(taskId, REASON_COMPLETED);

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/TaskController.java
@@ -256,16 +256,15 @@ public class TaskController {
         List<PermissionTypes> endpointPermissionsRequired = asList(OWN, EXECUTE);
         AccessControlResponse accessControlResponse = accessControlService.getRoles(authToken);
 
-        List<Task> tasks = camundaService.searchForCompletableTasks(
+        final GetTasksCompletableResponse<Task> response = camundaService.searchForCompletableTasks(
             searchEventAndCase,
             endpointPermissionsRequired,
             accessControlResponse
-
         );
         return ResponseEntity
             .ok()
             .cacheControl(CacheControl.noCache())
-            .body(new GetTasksCompletableResponse<>(tasks));
+            .body(response);
     }
 
     @ApiOperation("Cancel a Task identified by an id.")

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksCompletableResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksCompletableResponse.java
@@ -10,10 +10,16 @@ import java.util.List;
 @ToString
 public class GetTasksCompletableResponse<T extends Task> {
 
+    private final boolean taskRequiredForEvent;
     private final List<T> tasks;
 
-    public GetTasksCompletableResponse(List<T> tasks) {
+    public GetTasksCompletableResponse(boolean taskRequiredForEvent, List<T> tasks) {
+        this.taskRequiredForEvent = taskRequiredForEvent;
         this.tasks = tasks;
+    }
+
+    public boolean isTaskRequiredForEvent() {
+        return taskRequiredForEvent;
     }
 
     public List<T> getTasks() {

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksCompletableResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/response/GetTasksCompletableResponseTest.java
@@ -25,7 +25,7 @@ public class GetTasksCompletableResponseTest {
         List<Task> camundaTasks = Lists.newArrayList(camundaTask);
 
         final GetTasksCompletableResponse<Task> camundaTasksGetTaskResponse =
-            new GetTasksCompletableResponse<>(camundaTasks);
+            new GetTasksCompletableResponse<>(false, camundaTasks);
 
         assertThat(camundaTasksGetTaskResponse.getTasks().size()).isEqualTo(1);
         assertThat(camundaTasksGetTaskResponse.getTasks().get(0)).isEqualTo(camundaTask);


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-556

### Change description ###

1. Added new property task_required_for_event to search for completable response.
2. ExUI will decide whether to create a task for the event based on the property.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
