### PR TITLE
RWA-809 [SH] Upgrading version of transitive dependency langtags to r…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,6 +244,9 @@ dependencyManagement {
 
     //CVE-2021-28170
     dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+
+    //CVE-2020-23171
+    dependency group: 'com.nimbusds', name: 'lang-tag', version: '1.5'
   }
 }
 


### PR DESCRIPTION
…emove need for suppressing false negative owasp warning

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-809

### Change description ###

Update transitive dependency to remove owasp warning

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
