### PR TITLE
RWA-948: Adds deleted terminate reason to mark tasks as TERMINATED 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/DeleteTerminateByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/DeleteTerminateByIdControllerTest.java
@@ -150,5 +150,57 @@ class DeleteTerminateByIdControllerTest extends SpringBootIntegrationBaseTest {
                 ));
         }
     }
+
+    @Nested
+    @DisplayName("Terminate reason is deleted")
+    class Deleted {
+        @Test
+        void should_return_403_with_application_problem_response_when_client_is_not_allowed() throws Exception {
+
+            when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
+                .thenReturn(false);
+
+            TerminateTaskRequest req = new TerminateTaskRequest(new TerminateInfo(TerminateReason.DELETED));
+
+            mockMvc.perform(
+                delete(ENDPOINT_BEING_TESTED)
+                    .header(AUTHORIZATION, IDAM_AUTHORIZATION_TOKEN)
+                    .header(SERVICE_AUTHORIZATION, SERVICE_AUTHORIZATION_TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(asJsonString(req))
+            ).andExpect(
+                ResultMatcher.matchAll(
+                    status().isForbidden(),
+                    content().contentType(APPLICATION_PROBLEM_JSON_VALUE),
+                    jsonPath("$.type")
+                        .value("https://github.com/hmcts/wa-task-management-api/problem/forbidden"),
+                    jsonPath("$.title").value("Forbidden"),
+                    jsonPath("$.status").value(403),
+                    jsonPath("$.detail").value(
+                        "Forbidden: The action could not be completed because the client/user "
+                        + "had insufficient rights to a resource.")
+                ));
+        }
+
+        @Test
+        void should_return_204_and_delete_task() throws Exception {
+
+            when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
+                .thenReturn(true);
+
+            TerminateTaskRequest req = new TerminateTaskRequest(new TerminateInfo(TerminateReason.DELETED));
+
+            mockMvc.perform(
+                delete(ENDPOINT_BEING_TESTED)
+                    .header(AUTHORIZATION, IDAM_AUTHORIZATION_TOKEN)
+                    .header(SERVICE_AUTHORIZATION, SERVICE_AUTHORIZATION_TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(asJsonString(req))
+            ).andExpect(
+                ResultMatcher.matchAll(
+                    status().isNoContent()
+                ));
+        }
+    }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/enums/TerminateReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/enums/TerminateReason.java
@@ -1,5 +1,5 @@
 package uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.enums;
 
 public enum TerminateReason {
-    COMPLETED, CANCELLED
+    COMPLETED, CANCELLED, DELETED
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CFTTaskMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CFTTaskMapper.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -200,6 +201,11 @@ public class CFTTaskMapper {
         }
     }
 
+    public Map<String, Object> getTaskAttributes(TaskResource taskResource) {
+        return objectMapper.convertValue(taskResource, new TypeReference<HashMap<String, Object>>() {
+        });
+    }
+
     private WorkTypeResource extractWorkType(Map<TaskAttributeDefinition, Object> attributes) {
         String workTypeId = read(attributes, TASK_WORK_TYPE, null);
         return workTypeId == null ? null : new WorkTypeResource(workTypeId);
@@ -207,7 +213,7 @@ public class CFTTaskMapper {
 
     private Set<PermissionTypes> extractUnionOfPermissions(Set<TaskRoleResource> taskRoleResources) {
         //Using TreeSet to benefit from SortedSet
-        Set<PermissionTypes> permissionsFound = new TreeSet<>();
+        TreeSet<PermissionTypes> permissionsFound = new TreeSet<>();
         if (taskRoleResources != null) {
             taskRoleResources.forEach(taskRoleResource -> {
                 if (taskRoleResource.getRead()) {
@@ -231,11 +237,6 @@ public class CFTTaskMapper {
             });
         }
         return permissionsFound;
-    }
-
-    public Map<String, Object> getTaskAttributes(TaskResource taskResource) {
-        return objectMapper.convertValue(taskResource, new TypeReference<HashMap<String, Object>>() {
-        });
     }
 
     private Set<TaskRoleResource> mapPermissions(

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementService.java
@@ -637,6 +637,14 @@ public class TaskManagementService {
                 //Commit transaction
                 cftTaskDatabaseService.saveTask(task);
                 break;
+            case DELETED:
+                //Update cft task
+                task.setState(CFTTaskState.TERMINATED);
+                //Perform Camunda updates
+                camundaService.deleteCftTaskState(taskId);
+                //Commit transaction
+                cftTaskDatabaseService.saveTask(task);
+                break;
             default:
                 throw new IllegalStateException("Unexpected value: " + terminateInfo.getTerminateReason());
         }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/ExclusiveTaskActionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/ExclusiveTaskActionsControllerTest.java
@@ -133,6 +133,20 @@ class ExclusiveTaskActionsControllerTest {
     }
 
     @Test
+    void should_succeed_when_terminating_a_task_and_return_204_when_terminate_reason_is_deleted() {
+        TerminateTaskRequest req = new TerminateTaskRequest(new TerminateInfo(TerminateReason.DELETED));
+
+        when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
+            .thenReturn(true);
+
+        ResponseEntity<Void> response = exclusiveTaskActionsController
+            .terminateTask(SERVICE_AUTHORIZATION_TOKEN, taskId, req);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    @Test
     void should_fail_when_terminating_a_task_and_client_is_not_whitelisted_return_403() {
         TerminateTaskRequest req = new TerminateTaskRequest(new TerminateInfo(TerminateReason.CANCELLED));
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/enums/TerminateReasonTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/request/enums/TerminateReasonTest.java
@@ -10,11 +10,12 @@ class TerminateReasonTest {
     void simple_enum_example_outside_class_test() {
         assertEquals("CANCELLED", TerminateReason.CANCELLED.name());
         assertEquals("COMPLETED", TerminateReason.COMPLETED.name());
+        assertEquals("DELETED", TerminateReason.DELETED.name());
     }
 
     @Test
     void update_test_whenever_additions_to_assign_enum_are_made() {
         int enumLength = TerminateReason.values().length;
-        assertEquals(2, enumLength);
+        assertEquals(3, enumLength);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementServiceTest.java
@@ -260,8 +260,8 @@ class TaskManagementServiceTest extends CamundaHelpers {
 
             assertNotNull(response);
             assertEquals(mockedMappedTask, response);
-            verify(camundaService,times(0)).getTaskVariables(any());
-            verify(camundaService,times(0)).getMappedTask(any(), any());
+            verify(camundaService, times(0)).getTaskVariables(any());
+            verify(camundaService, times(0)).getMappedTask(any(), any());
             verifyNoInteractions(camundaService);
         }
 
@@ -284,8 +284,8 @@ class TaskManagementServiceTest extends CamundaHelpers {
                 .isInstanceOf(TaskNotFoundException.class)
                 .hasNoCause()
                 .hasMessage("Task Not Found Error: The task could not be found.");
-            verify(camundaService,times(0)).getTaskVariables(any());
-            verify(camundaService,times(0)).getMappedTask(any(), any());
+            verify(camundaService, times(0)).getTaskVariables(any());
+            verify(camundaService, times(0)).getMappedTask(any(), any());
             verifyNoInteractions(camundaService);
         }
 
@@ -308,8 +308,8 @@ class TaskManagementServiceTest extends CamundaHelpers {
                 .isInstanceOf(RoleAssignmentVerificationException.class)
                 .hasNoCause()
                 .hasMessage("Role Assignment Verification: The request failed the Role Assignment checks performed.");
-            verify(camundaService,times(0)).getTaskVariables(any());
-            verify(camundaService,times(0)).getMappedTask(any(), any());
+            verify(camundaService, times(0)).getTaskVariables(any());
+            verify(camundaService, times(0)).getMappedTask(any(), any());
             verifyNoInteractions(camundaService);
         }
     }
@@ -2896,6 +2896,46 @@ class TaskManagementServiceTest extends CamundaHelpers {
                 verify(cftTaskDatabaseService, times(1)).saveTask(taskResource);
             }
 
+
+            @Test
+            void should_throw_exception_when_task_resource_not_found() {
+
+                TaskResource taskResource = spy(TaskResource.class);
+
+                when(cftTaskDatabaseService.findByIdAndObtainPessimisticWriteLock(taskId))
+                    .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> taskManagementService.terminateTask(taskId, terminateInfo))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasNoCause()
+                    .hasMessage("Resource not found");
+                verify(camundaService, times(0)).deleteCftTaskState(taskId);
+                verify(cftTaskDatabaseService, times(0)).saveTask(taskResource);
+            }
+
+        }
+
+        @Nested
+        @DisplayName("When Terminate Reason is Deleted")
+        class Deleted {
+            TerminateInfo terminateInfo = new TerminateInfo(TerminateReason.DELETED);
+
+            @Test
+            void should_succeed() {
+
+                TaskResource taskResource = spy(TaskResource.class);
+
+                when(cftTaskDatabaseService.findByIdAndObtainPessimisticWriteLock(taskId))
+                    .thenReturn(Optional.of(taskResource));
+
+                when(cftTaskDatabaseService.saveTask(taskResource)).thenReturn(taskResource);
+
+                taskManagementService.terminateTask(taskId, terminateInfo);
+
+                assertEquals(CFTTaskState.TERMINATED, taskResource.getState());
+                verify(camundaService, times(1)).deleteCftTaskState(taskId);
+                verify(cftTaskDatabaseService, times(1)).saveTask(taskResource);
+            }
 
             @Test
             void should_throw_exception_when_task_resource_not_found() {


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-948

### Change description ###

When a task is cancelled via the DMN the wa-case-event handler will create a cancellation message to be sent to the cancellation sub-process.

When this cancellation is received camunda now stores the cancelled task with a cancellation reason of 'deleted'.

As a side effect, this prevents R2 termination of tasks that have been cancelled automatically. Since the job never calls the terminate endpoint to terminate these tasks in the cft task db. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
