### PR TITLE
Disable tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostConfigureTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostConfigureTaskTest.java
@@ -4,6 +4,7 @@ import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,7 @@ public class PostConfigureTaskTest extends SpringBootFunctionalBaseTest {
 
     @Test
     @Disabled("AM role-assignment enabled v1.1 of their validation which breaks this flow needs to be reviewed")
+    @Ignore
     public void given_configure_task_then_expect_task_state_is_assigned() throws Exception {
         caseId = createCcdCase();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostConfigureTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostConfigureTaskTest.java
@@ -5,6 +5,7 @@ import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.wataskmanagementapi.SpringBootFunctionalBaseTest;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CreateTaskMessage;
@@ -31,6 +32,7 @@ public class PostConfigureTaskTest extends SpringBootFunctionalBaseTest {
     }
 
     @Test
+    @Disabled("AM role-assignment enabled v1.1 of their validation which breaks this flow needs to be reviewed")
     public void given_configure_task_then_expect_task_state_is_assigned() throws Exception {
         caseId = createCcdCase();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostTaskConfigurationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostTaskConfigurationTest.java
@@ -4,6 +4,7 @@ import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.wataskmanagementapi.SpringBootFunctionalBaseTest;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CreateTaskMessage;
@@ -36,6 +37,7 @@ public class PostTaskConfigurationTest extends SpringBootFunctionalBaseTest {
     }
 
     @Test
+    @Disabled("AM role-assignment enabled v1.1 of their validation which breaks this flow needs to be reviewed")
     public void given_task_is_configured_then_expect_task_is_auto_assigned() throws Exception {
         caseId = createCcdCase();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostTaskConfigurationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/wataskconfigurationapi/controllers/PostTaskConfigurationTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.wataskmanagementapi.wataskconfigurationapi.controlle
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
@@ -38,6 +39,7 @@ public class PostTaskConfigurationTest extends SpringBootFunctionalBaseTest {
 
     @Test
     @Disabled("AM role-assignment enabled v1.1 of their validation which breaks this flow needs to be reviewed")
+    @Ignore
     public void given_task_is_configured_then_expect_task_is_auto_assigned() throws Exception {
         caseId = createCcdCase();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Disabled some tests that produced a 422 when trying to create a restricted role assignment.
AM role-assignment enabled v1.1 of their validation which breaks the flow of the tests they need to be reviewed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
