### PR TITLE
Optimiza query, using processInstanceId when searching history table

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/DeleteTerminateByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/DeleteTerminateByIdControllerTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.wataskmanagementapi.cft.repository.TaskResourceReposi
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.CamundaServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.TerminateTaskRequest;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.options.TerminateInfo;
+import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.CFTTaskDatabaseService;
 import uk.gov.hmcts.reform.wataskmanagementapi.services.TaskManagementService;
 
@@ -110,6 +111,8 @@ class DeleteTerminateByIdControllerTest extends SpringBootIntegrationBaseTest {
             CFTTaskDatabaseService cftTaskDatabaseService = new CFTTaskDatabaseService(taskResourceRepository);
             insertDummyTaskInDb(taskId, cftTaskDatabaseService);
             when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION_TOKEN);
+            when(camundaServiceApi.getTask(eq(SERVICE_AUTHORIZATION_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
             when(camundaServiceApi.searchHistory(eq(SERVICE_AUTHORIZATION_TOKEN), any())).thenReturn(emptyList());
             when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
                 .thenReturn(true);
@@ -172,6 +175,8 @@ class DeleteTerminateByIdControllerTest extends SpringBootIntegrationBaseTest {
             CFTTaskDatabaseService cftTaskDatabaseService = new CFTTaskDatabaseService(taskResourceRepository);
             insertDummyTaskInDb(taskId, cftTaskDatabaseService);
             when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION_TOKEN);
+            when(camundaServiceApi.getTask(eq(SERVICE_AUTHORIZATION_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
             when(camundaServiceApi.searchHistory(eq(SERVICE_AUTHORIZATION_TOKEN), any())).thenReturn(emptyList());
 
             when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
@@ -234,6 +239,8 @@ class DeleteTerminateByIdControllerTest extends SpringBootIntegrationBaseTest {
             CFTTaskDatabaseService cftTaskDatabaseService = new CFTTaskDatabaseService(taskResourceRepository);
             insertDummyTaskInDb(taskId, cftTaskDatabaseService);
             when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION_TOKEN);
+            when(camundaServiceApi.getTask(eq(SERVICE_AUTHORIZATION_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
             when(camundaServiceApi.searchHistory(eq(SERVICE_AUTHORIZATION_TOKEN), any())).thenReturn(emptyList());
             when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
                 .thenReturn(true);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/TaskManagementServiceTest.java
@@ -409,6 +409,8 @@ class TaskManagementServiceTest extends SpringBootIntegrationBaseTest {
 
                 Map<String, CamundaVariable> mockedVariables = createMockCamundaVariables();
                 when(camundaService.getTaskVariables(taskId)).thenReturn(mockedVariables);
+                when(camundaServiceApi.getTask(any(), any()))
+                    .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
 
                 doThrow(FeignException.FeignServerException.class)
                     .when(camundaServiceApi).searchHistory(any(), any());
@@ -436,6 +438,9 @@ class TaskManagementServiceTest extends SpringBootIntegrationBaseTest {
             void should_rollback_transaction_when_exception_occurs_calling_camunda() {
 
                 createAndSaveTestTask(taskId);
+                when(camundaServiceApi.getTask(any(), any()))
+                    .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
+
                 doThrow(FeignException.FeignServerException.class)
                     .when(camundaServiceApi).searchHistory(any(), any());
 
@@ -462,6 +467,10 @@ class TaskManagementServiceTest extends SpringBootIntegrationBaseTest {
             void should_rollback_transaction_when_exception_occurs_calling_camunda() {
 
                 createAndSaveTestTask(taskId);
+
+                when(camundaServiceApi.getTask(any(), any()))
+                    .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
+
                 doThrow(FeignException.FeignServerException.class)
                     .when(camundaServiceApi).searchHistory(any(), any());
 

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    lazy-initialization: true
   datasource:
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:postgresql:11.4://localhost/cft_task_db

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/camunda/CamundaTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/domain/entities/camunda/CamundaTask.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,6 +14,7 @@ import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.Ca
 @ToString
 @EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder
 public class CamundaTask {
 
     private String id;

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -367,6 +367,8 @@ public class CamundaService {
                 "processInstanceId", camundaTask.getProcessInstanceId(),
                 "variableName", CFT_TASK_STATE.value(),
                 "taskIdIn", singleton(taskId),
+                "includeDeleted", false,
+                "processDefinitionKey", WA_TASK_INITIATION_BPMN_PROCESS_DEFINITION_KEY,
                 "maxResults", 1
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaService.java
@@ -356,14 +356,20 @@ public class CamundaService {
      * @param taskId the task id
      */
     public void deleteCftTaskState(String taskId) {
-
-        Map<String, Object> body = Map.of(
-            "variableName", CFT_TASK_STATE.value(),
-            "taskIdIn", singleton(taskId),
-            "maxResults", 1
-        );
-
         try {
+
+            CamundaTask camundaTask = camundaServiceApi.getTask(
+                authTokenGenerator.generate(),
+                taskId
+            );
+
+            Map<String, Object> body = Map.of(
+                "processInstanceId", camundaTask.getProcessInstanceId(),
+                "variableName", CFT_TASK_STATE.value(),
+                "taskIdIn", singleton(taskId),
+                "maxResults", 1
+            );
+
             List<HistoryVariableInstance> results = camundaServiceApi.searchHistory(
                 authTokenGenerator.generate(),
                 body

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/CamundaServiceTest.java
@@ -562,6 +562,9 @@ class CamundaServiceTest extends CamundaHelpers {
                 "someValue"
             );
 
+            when(camundaServiceApi.getTask(eq(BEARER_SERVICE_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
+
             when(camundaServiceApi.searchHistory(eq(BEARER_SERVICE_TOKEN), any()))
                 .thenReturn(singletonList(historyVariableInstance));
 
@@ -584,6 +587,9 @@ class CamundaServiceTest extends CamundaHelpers {
         @Test
         void deleteCftTaskState_should_not_call_camunda_if_no_variable_found() {
 
+            when(camundaServiceApi.getTask(eq(BEARER_SERVICE_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
+
             when(camundaServiceApi.searchHistory(eq(BEARER_SERVICE_TOKEN), any()))
                 .thenReturn(emptyList());
 
@@ -600,7 +606,23 @@ class CamundaServiceTest extends CamundaHelpers {
         }
 
         @Test
+        void deleteCftTaskState_should_throw_a_server_error_exception_when_get_task_call_fails() {
+            doThrow(FeignException.FeignServerException.class)
+                .when(camundaServiceApi).getTask(eq(BEARER_SERVICE_TOKEN), any());
+
+            assertThatThrownBy(() -> camundaService.deleteCftTaskState(taskId))
+                .isInstanceOf(ServerErrorException.class)
+                .hasCauseInstanceOf(FeignException.class)
+                .hasMessage(
+                    "There was a problem when deleting the historic cftTaskState"
+                );
+        }
+
+        @Test
         void deleteCftTaskState_should_throw_a_server_error_exception_when_historic_call_fails() {
+
+            when(camundaServiceApi.getTask(eq(BEARER_SERVICE_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
 
             doThrow(FeignException.FeignServerException.class)
                 .when(camundaServiceApi).searchHistory(eq(BEARER_SERVICE_TOKEN), any());
@@ -621,6 +643,8 @@ class CamundaServiceTest extends CamundaHelpers {
                 CFT_TASK_STATE.value(),
                 "someValue"
             );
+            when(camundaServiceApi.getTask(eq(BEARER_SERVICE_TOKEN), any()))
+                .thenReturn(CamundaTask.builder().processInstanceId("someId").build());
 
             when(camundaServiceApi.searchHistory(eq(BEARER_SERVICE_TOKEN), any()))
                 .thenReturn(singletonList(historyVariableInstance));
@@ -709,7 +733,6 @@ class CamundaServiceTest extends CamundaHelpers {
                             + "Task assign and complete partially succeeded. "
                             + "The Task was assigned to the user making the request but the "
                             + "Task could not be completed.");
-
         }
 
         @Test

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Assertions.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Assertions.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.wataskmanagementapi.services.CamundaQueryBuilder.WA_TASK_INITIATION_BPMN_PROCESS_DEFINITION_KEY;
 
 public class Assertions {
 
@@ -56,6 +57,8 @@ public class Assertions {
             "variableName", variable,
             "variableValue", value,
             "taskIdIn", singleton(taskId),
+            "includeDeleted", false,
+            "processDefinitionKey", WA_TASK_INITIATION_BPMN_PROCESS_DEFINITION_KEY,
             "maxResults", 1
         );
 
@@ -82,6 +85,8 @@ public class Assertions {
             "variableName", variable,
             "variableValue", value,
             "processInstanceId", processInstanceId,
+            "includeDeleted", false,
+            "processDefinitionKey", WA_TASK_INITIATION_BPMN_PROCESS_DEFINITION_KEY,
             "maxResults", 1
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Fetch task to obtain process intance id in an attempt to improve camunda history table performance

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
