### PR TITLE
RWA-1153 updated default value to true so that when launch darkly is …

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProviderTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProviderTest.java
@@ -31,7 +31,7 @@ public class LaunchDarklyFeatureFlagProviderTest extends SpringBootFunctionalBas
     public void should_hit_launch_darkly_with_non_existent_key_and_return_default_value_for_boolean() {
         boolean launchDarklyFeature = featureFlagProvider.getBooleanValue(
             NON_EXISTENT_KEY, SOME_USER_ID,  SOME_USER_EMAIL);
-        assertThat(launchDarklyFeature, is(false));
+        assertThat(launchDarklyFeature, is(true));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostClaimByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostClaimByIdControllerTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.wataskmanagementapi.auth.permission.PermissionEvaluat
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.CamundaServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.IdamWebApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.RoleAssignmentServiceApi;
+import uk.gov.hmcts.reform.wataskmanagementapi.config.LaunchDarklyFeatureFlagProvider;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.utils.ServiceMocks;
 
@@ -50,6 +51,8 @@ class PostClaimByIdControllerTest extends SpringBootIntegrationBaseTest {
     private ServiceAuthorisationApi serviceAuthorisationApi;
     @MockBean
     private PermissionEvaluatorService permissionEvaluatorService;
+    @MockBean
+    private LaunchDarklyFeatureFlagProvider launchDarklyFeatureFlagProvider;
 
     private ServiceMocks mockServices;
     private String taskId;
@@ -72,6 +75,8 @@ class PostClaimByIdControllerTest extends SpringBootIntegrationBaseTest {
     void should_return_500_with_application_problem_response_when_task_update_call_fails() throws Exception {
 
         mockServices.mockServiceAPIs();
+
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(any(), any(), any())).thenReturn(false);
 
         when(permissionEvaluatorService.hasAccess(any(), any(), any()))
             .thenReturn(true);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostInitiateByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostInitiateByIdControllerTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.wataskmanagementapi.cft.repository.TaskResourceReposi
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.CamundaServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.IdamWebApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.RoleAssignmentServiceApi;
+import uk.gov.hmcts.reform.wataskmanagementapi.config.LaunchDarklyFeatureFlagProvider;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.InitiateTaskRequest;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.entities.TaskAttribute;
 import uk.gov.hmcts.reform.wataskmanagementapi.taskconfiguration.clients.CcdDataServiceApi;
@@ -96,6 +97,8 @@ class PostInitiateByIdControllerTest extends SpringBootIntegrationBaseTest {
     private RoleAssignmentServiceApi roleAssignmentServiceApi;
     @MockBean
     private ServiceAuthorisationApi serviceAuthorisationApi;
+    @MockBean
+    private LaunchDarklyFeatureFlagProvider launchDarklyFeatureFlagProvider;
     @Mock
     private CaseDetails caseDetails;
     private String taskId;
@@ -125,6 +128,7 @@ class PostInitiateByIdControllerTest extends SpringBootIntegrationBaseTest {
 
         when(clientAccessControlService.hasExclusiveAccess(SERVICE_AUTHORIZATION_TOKEN))
             .thenReturn(false);
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(any(), any(), any())).thenReturn(false);
 
         ZonedDateTime createdDate = ZonedDateTime.now();
         ZonedDateTime dueDate = createdDate.plusDays(1);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskAssignByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskAssignByIdControllerTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.wataskmanagementapi.auth.permission.PermissionEvaluat
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.CamundaServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.IdamWebApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.RoleAssignmentServiceApi;
+import uk.gov.hmcts.reform.wataskmanagementapi.config.LaunchDarklyFeatureFlagProvider;
 import uk.gov.hmcts.reform.wataskmanagementapi.controllers.request.AssignTaskRequest;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.utils.ServiceMocks;
@@ -51,6 +52,8 @@ class PostTaskAssignByIdControllerTest extends SpringBootIntegrationBaseTest {
     private ServiceAuthorisationApi serviceAuthorisationApi;
     @MockBean
     private PermissionEvaluatorService permissionEvaluatorService;
+    @MockBean
+    private LaunchDarklyFeatureFlagProvider launchDarklyFeatureFlagProvider;
 
     private ServiceMocks mockServices;
     private String taskId;
@@ -77,6 +80,8 @@ class PostTaskAssignByIdControllerTest extends SpringBootIntegrationBaseTest {
 
         when(permissionEvaluatorService.hasAccess(any(), any(), any()))
             .thenReturn(true);
+
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(any(), any(), any())).thenReturn(false);
 
         CamundaTask camundaTasks = mockServices.getCamundaTask("processInstanceId", taskId);
         when(camundaServiceApi.getTask(any(), eq(taskId))).thenReturn(camundaTasks);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskForSearchCompletionControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostTaskForSearchCompletionControllerTest.java
@@ -112,7 +112,7 @@ class PostTaskForSearchCompletionControllerTest extends SpringBootIntegrationBas
         mockServices.mockServiceAPIs();
 
         FeignException mockFeignException = mock(FeignException.class);
-
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(any(), any(), any())).thenReturn(false);
         when(mockFeignException.contentUTF8())
             .thenReturn(mockServices.createCamundaTestException(
                 "aCamundaErrorType", "There was a problem evaluating DMN"));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/controllers/PostUnclaimByIdControllerTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.wataskmanagementapi.auth.permission.PermissionEvaluat
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.CamundaServiceApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.IdamWebApi;
 import uk.gov.hmcts.reform.wataskmanagementapi.clients.RoleAssignmentServiceApi;
+import uk.gov.hmcts.reform.wataskmanagementapi.config.LaunchDarklyFeatureFlagProvider;
 import uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmanagementapi.utils.ServiceMocks;
 
@@ -48,6 +49,8 @@ class PostUnclaimByIdControllerTest extends SpringBootIntegrationBaseTest {
     private ServiceAuthorisationApi serviceAuthorisationApi;
     @MockBean
     private PermissionEvaluatorService permissionEvaluatorService;
+    @MockBean
+    private LaunchDarklyFeatureFlagProvider launchDarklyFeatureFlagProvider;
 
     private ServiceMocks mockServices;
     private String taskId;
@@ -74,6 +77,7 @@ class PostUnclaimByIdControllerTest extends SpringBootIntegrationBaseTest {
 
         when(permissionEvaluatorService.hasAccessWithAssigneeCheckAndHierarchy(any(), any(), any(), any(), any()))
             .thenReturn(true);
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(any(), any(), any())).thenReturn(false);
 
         CamundaTask camundaTasks = mockServices.getCamundaTask("processInstanceId", taskId);
         when(camundaServiceApi.getTask(any(), eq(taskId))).thenReturn(camundaTasks);

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProvider.java
@@ -25,7 +25,7 @@ public class LaunchDarklyFeatureFlagProvider {
         boolean result =  ldClient.boolVariation(
             featureFlag.getKey(),
             createLaunchDarklyUser(userId, email),
-            false);
+            true);
         log.info("Feature flag '{}' has evaluated to '{}'", featureFlag.getKey(), result);
         return result;
     }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/config/LaunchDarklyFeatureFlagProviderTest.java
@@ -39,8 +39,8 @@ class LaunchDarklyFeatureFlagProviderTest {
 
     @ParameterizedTest
     @CsvSource({
-        "false, true, true",
-        "false, false, false"
+        "true, true, true",
+        "true, false, false"
     })
     void getBooleanValue_return_expectedFlagValue(
         boolean defaultValue,


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1153


### Change description ###
Changed default return value of the boolean flag to true so that launch darkly returns true when it is not reachable


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
