### PR TITLE
RWA-1297: spring boot upgrade to 2.6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.4'
+  id 'org.springframework.boot' version '2.6.6'
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,30 +16,6 @@
         <cpe>cpe:/a:nim-lang:nim-lang</cpe>
         <cve>CVE-2020-23171</cve>
     </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22060</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring security version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22112</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our open feign version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22044</cve>
-    </suppress>
     <suppress>
         <notes><![CDATA[
    file name: spring-security-core-5.4.9.jar
@@ -84,12 +60,5 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
         <cve>CVE-2022-21724</cve>
-    </suppress>
-    <suppress until="2022-05-01">
-      <notes><![CDATA[
-      file name: spring-beans-5.3.16.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
-      <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1297


### Change description ###
Upgraded to spring boot 2.6.6 due to https://nvd.nist.gov/vuln/detail/CVE-2022-22950


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
