### PR TITLE
RWA-1348 Solve CVEs with postgres driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,8 +163,8 @@ jacocoTestCoverageVerification {
 jacocoTestReport {
   executionData(test, integration)
   reports {
-    xml.enabled = true
-    csv.enabled = false
+    xml.required = true
+    csv.required = false
     xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
@@ -228,6 +228,9 @@ dependencyUpdates {
 // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
 dependencyCheck {
   suppressionFile = 'config/owasp/suppressions.xml'
+
+  //CVE Scanning only relevant to production code that is published, not test or other implementations
+  scanConfigurations += 'releaseCompileClasspath'
 
   analyzers {
     // Disable scanning of .NET related binaries
@@ -346,7 +349,7 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-paranamer', version: '2.12.0'
 
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.0'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.1'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
   // required to convert postgres to hibernate types
   implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.14.0'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,20 +47,6 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <cve>CVE-2020-36518</cve>
     </suppress>
-    <suppress until="2022-05-01">
-        <notes><![CDATA[
-   file name: postgresql-42.3.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-        <cve>CVE-2022-26520</cve>
-    </suppress>
-    <suppress until="2022-05-01">
-        <notes><![CDATA[
-   file name: postgresql-42.3.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-        <cve>CVE-2022-21724</cve>
-    </suppress>
     <suppress until="2022-06-01">
         <notes><![CDATA[
    file name: spring-plugin-core-2.0.0.RELEASE.jar


### PR DESCRIPTION

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1348


### Change description ###
Upgraded postgres driver 42.3.1 to 42.3.3 which fixes CVE-2022-26520 and CVE-2022-21724


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
