### PR TITLE
upgraded launchdarkly version due to cve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,7 +326,7 @@ dependencies {
 
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.2.2'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.8.1'
   implementation 'org.apache.commons:commons-lang3:3.12.0'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1379



### Change description ###

upgraded launchdarkly-java-server-sdk due to https://github.com/advisories/GHSA-4jrv-ppp4-jm57

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
