### PR TITLE
RWA-1776: Upgraded launchdarkly-java-server-sdk 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.0'
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.owasp.dependencycheck' version '7.1.2'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'
   id 'info.solidsoft.pitest' version '1.7.4'
@@ -301,7 +301,7 @@ dependencies {
 
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.8.1'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,24 +26,4 @@
       https://tanzu.vmware.com/security/cve-2022-22978</notes>
     <cve>CVE-2022-22978</cve>
   </suppress>
-  <suppress>
-    <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      Only affects Amazon Corretto when hot patch is enabled
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
-    <cve>CVE-2022-33915</cve>
-  </suppress>
-  <suppress>
-    <notes>False positive (https://github.com/jeremylong/DependencyCheck/issues/4671)</notes>
-    <cve>CVE-2022-31569</cve>
-  </suppress>
-  <suppress>
-    <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-25857</cve>
-  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,4 +26,8 @@
       https://tanzu.vmware.com/security/cve-2022-22978</notes>
     <cve>CVE-2022-22978</cve>
   </suppress>
+  <suppress>
+    <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
+    <cve>CVE-2022-34305</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1776


### Change description ###
 Upgraded launchdarkly-java-server-sdk due to CVE-2022-38749, CVE-2022-38751, CVE-2022-38750


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
