### PR TITLE
Rwa-1512-task search by role category CTSC (#724)

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchCriteriaConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/consumer/wa/TaskManagementGetTasksBySearchCriteriaConsumerTest.java
@@ -137,6 +137,23 @@ public class TaskManagementGetTasksBySearchCriteriaConsumerTest extends SpringBo
             .toPact();
     }
 
+    @Pact(provider = "wa_task_management_api_search", consumer = "wa_task_management_api")
+    public RequestResponsePact executeSearchQueryWithRoleCategory200(PactDslWithProvider builder) {
+        return builder
+            .given("appropriate tasks are returned by criteria with role category")
+            .uponReceiving("Provider receives a POST /task request from a WA API")
+            .path(WA_SEARCH_QUERY)
+            .method(HttpMethod.POST.toString())
+            .headers(getTaskManagementServiceResponseHeaders())
+            .matchHeader(AUTHORIZATION, AUTH_TOKEN)
+            .matchHeader(SERVICE_AUTHORIZATION, SERVICE_AUTH_TOKEN)
+            .body(createSearchByRoleCategoryRequest(), String.valueOf(ContentType.JSON))
+            .willRespondWith()
+            .status(HttpStatus.OK.value())
+            .body(createResponseForGetTaskForRoleCategory())
+            .toPact();
+    }
+
     @Test
     @PactTestFor(pactMethod = "executeSearchQuery200", pactVersion = PactSpecVersion.V3)
     void testSearchQuery200Test(MockServer mockServer) {
@@ -210,6 +227,19 @@ public class TaskManagementGetTasksBySearchCriteriaConsumerTest extends SpringBo
             .headers(getHttpHeaders())
             .contentType(ContentType.JSON)
             .body(createSearchEventCaseWithWorkTypeRequest())
+            .post(mockServer.getUrl() + WA_SEARCH_QUERY)
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "executeSearchQueryWithRoleCategory200", pactVersion = PactSpecVersion.V3)
+    void testSearchQueryWithRoleCategory200Test(MockServer mockServer) {
+        SerenityRest
+            .given()
+            .headers(getHttpHeaders())
+            .contentType(ContentType.JSON)
+            .body(createSearchByRoleCategoryRequest())
             .post(mockServer.getUrl() + WA_SEARCH_QUERY)
             .then()
             .statusCode(HttpStatus.OK.value());
@@ -433,4 +463,56 @@ public class TaskManagementGetTasksBySearchCriteriaConsumerTest extends SpringBo
                + "}";
     }
 
+    private String createSearchByRoleCategoryRequest() {
+
+        return "{\n"
+               + "    \"search_parameters\": [\n"
+               + "         {\n"
+               + "             \"key\": \"role_category\",\n"
+               + "             \"operator\": \"IN\",\n"
+               + "             \"values\":"
+               + "                 [\n"
+               + "                     \"CTSC\"\n"
+               + "                 ]\n"
+               + "          }\n"
+               + "      ]\n"
+               + "  }\n";
+
+    }
+
+    private DslPart createResponseForGetTaskForRoleCategory() {
+        return newJsonBody(
+            o -> o
+                .minArrayLike("tasks", 1, 1,
+                    task -> task
+                        .stringType("id", "4d4b6fgh-c91f-433f-92ac-e456ae34f72a")
+                        .stringType("name", "review appeal skeleton argument")
+                        .stringType("type", "reviewAppealSkeletonArgument")
+                        .stringType("task_state", "unassigned")
+                        .stringType("task_system", "SELF")
+                        .stringType("security_classification", "PUBLIC")
+                        .stringType("task_title", "review appeal skeleton argument")
+                        .datetime("due_date", "yyyy-MM-dd'T'HH:mm:ssZ")
+                        .datetime("created_date", "yyyy-MM-dd'T'HH:mm:ssZ")
+                        .stringType("assignee", "10bac6bf-80a7-4c81-b2db-516aba826be6")
+                        .booleanType("auto_assigned", true)
+                        .stringType("execution_type", "Case Management Task")
+                        .stringType("jurisdiction", "WA")
+                        .stringType("region", "1")
+                        .stringType("location", "765324")
+                        .stringType("location_name", "Taylor House")
+                        .stringType("case_type_id", "WaCaseType")
+                        .stringType("case_id", "1617708245335311")
+                        .stringType("case_category", "Protection")
+                        .stringType("case_name", "Bob Smith")
+                        .booleanType("warnings", false)
+                        .stringType("case_management_category", "Some Case Management Category")
+                        .stringType("work_type_id", "hearing_work")
+                        .stringType("work_type_label", "Hearing work")
+                        .stringValue("role_category", "CTSC")
+                        .stringType("description", "aDescription")
+                        .stringType("next_hearing_id", "nextHearingId")
+                        .datetime("next_hearing_date", "yyyy-MM-dd'T'HH:mm:ssZ")
+                )).build();
+    }
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/provider/TaskManagementGetTaskBySearchCriteriaPactTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/wataskmanagementapi/provider/TaskManagementGetTaskBySearchCriteriaPactTest.java
@@ -72,6 +72,11 @@ public class TaskManagementGetTaskBySearchCriteriaPactTest extends SpringBootCon
         setInitMockForSearchTaskWithWarningsOnly();
     }
 
+    @State({"appropriate tasks are returned by criteria with role category"})
+    public void getTasksBySearchCriteriaWithRoleCategory() {
+        setInitMockForSearchTaskWithRoleCategory();
+    }
+
     public Task createTaskWithNoWarnings() {
         final TaskPermissions permissions = new TaskPermissions(
             Set.of(
@@ -168,7 +173,7 @@ public class TaskManagementGetTaskBySearchCriteriaPactTest extends SpringBootCon
             RoleCategory.LEGAL_OPERATIONS.name(),
             "a description",
             getAdditionalProperties(),
-                "nextHearingId",
+            "nextHearingId",
             ZonedDateTime.now(),
             500,
             5000,
@@ -213,6 +218,56 @@ public class TaskManagementGetTaskBySearchCriteriaPactTest extends SpringBootCon
             "Hearing work",
             permissions,
             RoleCategory.LEGAL_OPERATIONS.name(),
+            "aDescription",
+            getAdditionalProperties(),
+            "nextHearingId",
+            ZonedDateTime.now(),
+            500,
+            5000,
+            ZonedDateTime.now()
+        );
+    }
+
+    public Task createTaskForRoleCategorySearch() {
+        final TaskPermissions permissions = new TaskPermissions(
+            Set.of(
+                PermissionTypes.READ,
+                PermissionTypes.OWN,
+                PermissionTypes.EXECUTE,
+                PermissionTypes.CANCEL,
+                PermissionTypes.MANAGE,
+                PermissionTypes.REFER
+            )
+        );
+
+        return new Task(
+            "4d4b6fgh-c91f-433f-92ac-e456ae34f72a",
+            "review appeal skeleton argument",
+            "reviewAppealSkeletonArgument",
+            "unassigned",
+            "SELF",
+            "PUBLIC",
+            "review appeal skeleton argument",
+            ZonedDateTime.now(),
+            ZonedDateTime.now(),
+            "10bac6bf-80a7-4c81-b2db-516aba826be6",
+            false,
+            "Case Management Task",
+            "IA",
+            "1",
+            "765324",
+            "Taylor House",
+            "Asylum",
+            "1617708245335311",
+            "Protection",
+            "Bob Smith",
+            false,
+            new WarningValues(Collections.emptyList()),
+            "Case Management Category",
+            "hearing_work",
+            "Hearing work",
+            permissions,
+            RoleCategory.CTSC.name(),
             "aDescription",
             getAdditionalProperties(),
             "nextHearingId",
@@ -323,4 +378,20 @@ public class TaskManagementGetTaskBySearchCriteriaPactTest extends SpringBootCon
             .thenReturn(singletonList(createTaskWithNoWarnings()));
     }
 
+    private void setInitMockForSearchTaskWithRoleCategory() {
+        Optional<AccessControlResponse> accessControlResponse = Optional.of(mock((AccessControlResponse.class)));
+        UserInfo userInfo = mock(UserInfo.class);
+        when(userInfo.getUid()).thenReturn("dummyUserId");
+        when(accessControlResponse.get().getUserInfo()).thenReturn(userInfo);
+        when(accessControlService.getAccessControlResponse(anyString()))
+            .thenReturn(accessControlResponse);
+
+        when(launchDarklyFeatureFlagProvider.getBooleanValue(
+                FeatureFlag.RELEASE_2_TASK_QUERY, accessControlResponse.get().getUserInfo().getUid(),
+                accessControlResponse.get().getUserInfo().getEmail()
+            )
+        ).thenReturn(false);
+        when(taskManagementService.searchWithCriteria(any(), anyInt(), anyInt(), any()))
+            .thenReturn(singletonList(createTaskForRoleCategorySearch()));
+    }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/watasks/controllers/PostTaskInitiateByIdControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/watasks/controllers/PostTaskInitiateByIdControllerTest.java
@@ -151,7 +151,7 @@ public class PostTaskInitiateByIdControllerTest extends SpringBootFunctionalBase
     }
 
     @Test
-    public void should_return_priorty_date_when_initiating_a_task_without_hearing_date() {
+    public void should_return_priority_date_when_initiating_a_task_without_hearing_date() {
         TestVariables taskVariables
             = common.setupWATaskAndRetrieveIds("requests/ccd/wa_case_data_no_hearing_date.json",
             "processApplication",

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/watasks/controllers/PostTaskSearchControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmanagementapi/watasks/controllers/PostTaskSearchControllerTest.java
@@ -37,6 +37,7 @@ import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.search.par
 import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.search.parameter.SearchParameterKey.CASE_ID;
 import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.search.parameter.SearchParameterKey.JURISDICTION;
 import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.search.parameter.SearchParameterKey.LOCATION;
+import static uk.gov.hmcts.reform.wataskmanagementapi.domain.entities.search.parameter.SearchParameterKey.ROLE_CATEGORY;
 
 @SuppressWarnings("checkstyle:LineLength")
 public class PostTaskSearchControllerTest extends SpringBootFunctionalBaseTest {
@@ -276,4 +277,72 @@ public class PostTaskSearchControllerTest extends SpringBootFunctionalBaseTest {
         tasksCreated
             .forEach(task -> common.cleanUpTask(task.getTaskId()));
     }
+
+    @Test
+    public void should_return_a_200_with_role_category_ctsc() {
+        common.setupCFTCtscRoleAssignmentForWA(caseworkerCredentials.getHeaders());
+        List<TestVariables> tasksCreated = new ArrayList<>();
+
+        TestVariables taskVariables
+            = common.setupWATaskAndRetrieveIds("requests/ccd/wa_case_data_no_hearing_date.json",
+            "reviewAppealSkeletonArgument",
+            "Review Appeal Skeleton Argument");
+        tasksCreated.add(taskVariables);
+        initiateTask(taskVariables, caseworkerCredentials.getHeaders());
+
+        List<String> taskIds = tasksCreated.stream().map(TestVariables::getTaskId).collect(Collectors.toList());
+        List<String> caseIds = tasksCreated.stream().map(TestVariables::getCaseId).collect(Collectors.toList());
+
+        SearchTaskRequest searchTaskRequest = new SearchTaskRequest(asList(
+            new SearchParameterList(JURISDICTION, SearchOperator.IN, singletonList("WA")),
+            new SearchParameterList(ROLE_CATEGORY, SearchOperator.IN, singletonList("CTSC")),
+            new SearchParameterList(CASE_ID, SearchOperator.IN, caseIds)
+        ));
+
+        Response result = restApiActions.post(
+            ENDPOINT_BEING_TESTED + "?first_result=0&max_results=10",
+            searchTaskRequest,
+            caseworkerCredentials.getHeaders()
+        );
+
+        result.then().assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("tasks.size()", lessThanOrEqualTo(10)) //Default max results
+            .body("tasks.id", everyItem(notNullValue()))
+            .body("tasks.id", hasItem(is(in(taskIds))))
+            .body("tasks.name", everyItem(equalTo("Review Appeal Skeleton Argument")))
+            .body("tasks.type", everyItem(equalTo("reviewAppealSkeletonArgument")))
+            .body("tasks.task_state", everyItem(equalTo("unassigned")))
+            .body("tasks.task_system", everyItem(equalTo("SELF")))
+            .body("tasks.security_classification", everyItem(equalTo("PUBLIC")))
+            .body("tasks.task_title", everyItem(equalTo("Review Appeal Skeleton Argument")))
+            .body("tasks.created_date", everyItem(notNullValue()))
+            .body("tasks.due_date", everyItem(notNullValue()))
+            .body("tasks.location_name", everyItem(equalTo("Taylor House")))
+            .body("tasks.location", everyItem(equalTo("765324")))
+            .body("tasks.execution_type", everyItem(equalTo("Case Management Task")))
+            .body("tasks.jurisdiction", everyItem(equalTo("WA")))
+            .body("tasks.region", everyItem(equalTo("1")))
+            .body("tasks.case_type_id", everyItem(equalTo("WaCaseType")))
+            .body("tasks.case_id", hasItem(is(in(caseIds))))
+            .body("tasks.case_category", everyItem(equalTo("Protection")))
+            .body("tasks.case_name", everyItem(equalTo("Bob Smith")))
+            .body("tasks.auto_assigned", everyItem(equalTo(false)))
+            .body("tasks.warnings", everyItem(equalTo(false)))
+            .body("tasks.case_management_category", everyItem(equalTo("Protection")))
+            .body("tasks.work_type_id", everyItem(equalTo("hearing_work")))
+            .body("tasks.permissions.values", everyItem(equalToObject(List.of("Read", "Own", "Cancel"))))
+            .body("tasks.description", everyItem(equalTo("[Request respondent review](/case/WA/WaCaseType"
+                                                         + "/${[CASE_REFERENCE]}/trigger/requestRespondentReview)<br />"
+                                                         + "[Request case edit](/case/WA/WaCaseType/${[CASE_REFERENCE]}"
+                                                         + "/trigger/requestCaseEdit)")))
+            .body("tasks.role_category", everyItem(equalTo("CTSC")))
+            .body("tasks.minor_priority", everyItem(equalTo(500)))
+            .body("tasks.major_priority", everyItem(equalTo(5000)))
+            .body("total_records", equalTo(1));
+
+        tasksCreated
+            .forEach(task -> common.cleanUpTask(task.getTaskId()));
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/role/entities/enums/RoleCategory.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/auth/role/entities/enums/RoleCategory.java
@@ -3,5 +3,5 @@ package uk.gov.hmcts.reform.wataskmanagementapi.auth.role.entities.enums;
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 
 public enum RoleCategory {
-    JUDICIAL, LEGAL_OPERATIONS, ADMIN, @JsonEnumDefaultValue UNKNOWN
+    JUDICIAL, LEGAL_OPERATIONS, ADMIN, CTSC, @JsonEnumDefaultValue UNKNOWN
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -134,4 +134,3 @@ caffeine:
     unit: MINUTES
 
 initiation_job_running: ${INITIATION_JOB_RUNNING:false}
-

--- a/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Common.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/wataskmanagementapi/utils/Common.java
@@ -86,12 +86,12 @@ public class Common {
         Map<CamundaVariableDefinition, String> variablesToUseAsOverride, String jurisdiction, String caseType
     ) {
         String caseId = given.iCreateACcdCase();
-        return setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(variablesToUseAsOverride,  caseId, jurisdiction, caseType, DEFAULT_WARNINGS, 1);
+        return setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(variablesToUseAsOverride, caseId, jurisdiction, caseType, DEFAULT_WARNINGS, 1);
     }
 
     public TestVariables setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(
         Map<CamundaVariableDefinition, String> variablesToUseAsOverride, String caseId, String jurisdiction, String caseType, int taskIndex) {
-        return setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(variablesToUseAsOverride,  caseId, jurisdiction, caseType, DEFAULT_WARNINGS, taskIndex);
+        return setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(variablesToUseAsOverride, caseId, jurisdiction, caseType, DEFAULT_WARNINGS, taskIndex);
     }
 
     public TestVariables setupTaskWithCaseIdAndRetrieveIdsWithCustomVariablesOverride(


### PR DESCRIPTION
* RWA-1514 ctsc changes implemented

* RWA-1514-arrange dmn for ctsc and reviewAppealSkeletonArgument

* reviewAppealSkeletonArgument initiation test added

* reviewAppealSkeletonArgument search by role category CTSC test added

* test coveraged increased

* an FT fixed

* should_return_a_200_with_task_when_next_hearing_date_is_empty FT fixed

* initiation FT added for reviewAppealSkeletonArgument with CTSC

* RWA-1512 search task by role category CTSC

* rebase master

* pact tests added for role caategory CTSC

* allow new build

* arrange contract test

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
