### PR TITLE
RWA-2037 change the order of repos so that dependencies can be resolved

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,8 +265,8 @@ dependencyManagement {
 
 repositories {
   mavenLocal()
-  maven { url 'https://jitpack.io' }
   mavenCentral()
+  maven { url 'https://jitpack.io' }
 }
 
 def versions = [


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-2037


### Change description ###
Change the order of repositories so that dependencies that cannot be resolved in jitpak.io can be resolved in mavenCentral.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
