### PR TITLE
Correcting wal_level requirements

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -107,12 +107,7 @@ module "wa_task_management_api_database_flexible_replica" {
       name : var.postgresql_database_name
     }
   ]
-  pgsql_server_configuration = [
-    {
-      name  = "wal_level"
-      value = "logical"
-    }
-  ]
+  
   pgsql_version      = 14
   common_tags        = local.common_tags
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -107,6 +107,12 @@ module "wa_task_management_api_database_flexible_replica" {
       name : var.postgresql_database_name
     }
   ]
+  pgsql_server_configuration = [
+    {
+      name  = "wal_level"
+      value = "logical"
+    }
+  ]
   pgsql_version      = 14
   common_tags        = local.common_tags
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReportingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReportingService.java
@@ -67,12 +67,9 @@ public class MIReportingService {
         Objects.requireNonNull(taskResourceRepository, "Primary Task DB repo is null.");
         Objects.requireNonNull(taskResourceRepository, "Replica Task DB repo is null.");
 
-        if (!taskResourceRepository.showWalLevel().equals(WAL_LEVEL)
-            || !reportableTaskRepository.showWalLevel().equals(WAL_LEVEL)) {
-
-            log.error("WAL LEVEL for primary DB; {}, replicaDB: {}.  These must be set to logical",
-                taskResourceRepository.showWalLevel(),
-                reportableTaskRepository.showWalLevel());
+        if (!taskResourceRepository.showWalLevel().equals(WAL_LEVEL)) {
+            log.error("WAL LEVEL for primaryDB: {}. This must be set to logical for replication to work.",
+                taskResourceRepository.showWalLevel());
             return;
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReportingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReportingServiceTest.java
@@ -84,7 +84,7 @@ class MIReportingServiceTest {
         when(taskResourceRepository.countPublications()).thenReturn(1);
         when(taskResourceRepository.countPublicationTables()).thenReturn(1);
         when(taskResourceRepository.showWalLevel()).thenReturn("logical");
-        when(reportableTaskMock.showWalLevel()).thenReturn("logical");
+        when(reportableTaskMock.showWalLevel()).thenReturn("replica");
 
         SubscriptionCreator subscriptionCreator = mock(SubscriptionCreator.class);
 
@@ -164,7 +164,7 @@ class MIReportingServiceTest {
         when(taskResourceRepository.countReplicationSlots()).thenReturn(1);
         when(taskResourceRepository.countPublications()).thenReturn(0);
         when(taskResourceRepository.showWalLevel()).thenReturn("logical");
-        when(reportableTaskMock.showWalLevel()).thenReturn("logical");
+        when(reportableTaskMock.showWalLevel()).thenReturn("replica");
         TaskHistoryResourceRepository taskHistoryResourceRepository = mock(TaskHistoryResourceRepository.class);
         when(taskHistoryResourceRepository.countSubscriptions()).thenReturn(0);
         SubscriptionCreator subscriptionCreator = mock(SubscriptionCreator.class);
@@ -188,7 +188,7 @@ class MIReportingServiceTest {
 
         when(taskResourceRepository.countReplicationSlots()).thenReturn(0);
         when(taskResourceRepository.showWalLevel()).thenReturn("logical");
-        when(reportableTaskMock.showWalLevel()).thenReturn("logical");
+        when(reportableTaskMock.showWalLevel()).thenReturn("replica");
 
         SubscriptionCreator subscriptionCreator = mock(SubscriptionCreator.class);
         miReportingService = new MIReportingService(null,
@@ -203,13 +203,12 @@ class MIReportingServiceTest {
     }
 
     @Test
-    void should_return_if_wal_level_is_not_logical() {
+    void should_return_if_primary_wal_level_is_not_logical() {
         TaskResourceRepository taskResourceRepository = mock(TaskResourceRepository.class);
         ReportableTaskRepository reportableTaskMock = mock(ReportableTaskRepository.class);
 
         when(taskResourceRepository.countReplicationSlots()).thenReturn(0);
         when(taskResourceRepository.showWalLevel()).thenReturn("replica");
-        when(reportableTaskMock.showWalLevel()).thenReturn("replica");
 
         miReportingService = new MIReportingService(null,
             taskResourceRepository,
@@ -222,7 +221,6 @@ class MIReportingServiceTest {
         verify(taskResourceRepository, times(0)).createReplicationSlot();
         verify(taskResourceRepository, times(0)).createPublication();
         verify(taskResourceRepository, times(2)).showWalLevel();
-        verify(reportableTaskMock, times(1)).showWalLevel();
 
     }
 


### PR DESCRIPTION
wal_level on the replica DB does not need to be logical.  The default replica level is sufficient and this is already there.