### PR TITLE
Add SDP read only user to postgres flexible replica

### DIFF
--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -1,0 +1,61 @@
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "sdp_vault"
+  subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription
+}
+
+locals {
+  sdp_cft_environments_map = {
+    sandbox  = "sbox"
+    aat      = "dev"
+    perftest = "test"
+  }
+
+  sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
+
+  sdp_environment_ids = {
+    sbox = {
+      subscription = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
+    }
+    dev = {
+      subscription = "867a878b-cb68-4de5-9741-361ac9e178b6"
+    }
+    test = {
+      subscription = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
+    }
+    ithc = {
+      subscription = "ba71a911-e0d6-4776-a1a6-079af1df7139"
+    }
+    stg = {
+      subscription = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+    }
+    prod = {
+      subscription = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+    }
+  }
+}
+
+//Only adding read user for the replica created by module wa_task_management_api_database_flexible_replica
+module "sdp_db_user" {
+
+  providers = {
+    azurerm.sdp_vault = azurerm.sdp_vault
+  }
+
+  source = "git::https://github.com/hmcts/terraform-module-sdp-db-user.git?ref=master"
+  env    = local.sdp_environment
+
+  server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica"
+  server_fqdn       = module.wa_task_management_api_database_flexible_replica.fqdn
+  server_admin_user = module.wa_task_management_api_database_flexible_replica.username
+  server_admin_pass = module.wa_task_management_api_database_flexible_replica.password
+
+  databases = [
+    {
+      name : var.postgresql_database_name
+    }
+  ]
+
+  common_tags = local.common_tags
+}

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -59,7 +59,7 @@ module "sdp_db_user" {
   ]
 
   database_schemas = {
-    var.postgresql_database_name = [var.postgresql_database_name]
+    cft_task_db = ["cft_task_db"]
   }
 
   common_tags = local.common_tags

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -43,7 +43,7 @@ module "sdp_db_user" {
     azurerm.sdp_vault = azurerm.sdp_vault
   }
 
-  source = "git::https://github.com/hmcts/terraform-module-sdp-db-user.git?ref=master"
+  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
   env    = local.sdp_environment
 
   server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica"

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -43,7 +43,7 @@ module "sdp_db_user" {
     azurerm.sdp_vault = azurerm.sdp_vault
   }
 
-  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
+  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=explciitly-set-provider"
   env    = local.sdp_environment
 
   server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica"

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -43,7 +43,7 @@ module "sdp_db_user" {
     azurerm.sdp_vault = azurerm.sdp_vault
   }
 
-  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=explciitly-set-provider"
+  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
   env    = local.sdp_environment
 
   server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica"

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -47,7 +47,7 @@ module "sdp_db_user" {
   source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
   env    = local.sdp_environment
 
-  server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica-${var.env}"
+  server_name       = var.env == "demo" ? "${var.postgres_db_component_name}-postgres-db-flexible-replica-${var.env}" : "${var.postgres_db_component_name}-postgres-db-flexible-replica"
   server_fqdn       = module.wa_task_management_api_database_flexible_replica.fqdn
   server_admin_user = module.wa_task_management_api_database_flexible_replica.username
   server_admin_pass = module.wa_task_management_api_database_flexible_replica.password

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -10,6 +10,7 @@ locals {
     sandbox  = "sbox"
     aat      = "dev"
     perftest = "test"
+    demo     = "dev"
   }
 
   sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
@@ -36,7 +37,7 @@ locals {
   }
 }
 
-//Only adding read user for the replica created by module wa_task_management_api_database_flexible_replica
+//Only adding read user for the replica created by module wa_task_management_api_database_flexible_replica. Server name has environment suffix due to duplicate mapping to dev.
 module "sdp_db_user" {
 
   providers = {
@@ -46,7 +47,7 @@ module "sdp_db_user" {
   source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
   env    = local.sdp_environment
 
-  server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica"
+  server_name       = "${var.postgres_db_component_name}-postgres-db-flexible-replica-${var.env}"
   server_fqdn       = module.wa_task_management_api_database_flexible_replica.fqdn
   server_admin_user = module.wa_task_management_api_database_flexible_replica.username
   server_admin_pass = module.wa_task_management_api_database_flexible_replica.password

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -58,4 +58,8 @@ module "sdp_db_user" {
   ]
 
   common_tags = local.common_tags
+
+  depends_on = [
+    module.wa_task_management_api_database_flexible_replica
+  ]
 }

--- a/infrastructure/sdp.tf
+++ b/infrastructure/sdp.tf
@@ -58,6 +58,10 @@ module "sdp_db_user" {
     }
   ]
 
+  database_schemas = {
+    var.postgresql_database_name = [var.postgresql_database_name]
+  }
+
   common_tags = local.common_tags
 
   depends_on = [


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RWA-2747

The new provider will have scope to access the subscription DTS-SHAREDSERVICES-{env} where the mi-vault that will store the read user username and password is.

Locals will map CFT envs, specifically sandbox, aat and perftest to SDS envs sbox, dev and test respectively.
Subscription IDs provided  are for DTS-SHAREDSERVICES-{env} and not considered PII.
The module will run a script against the specified postgres flexible db to create the SDP read user and store the user password into mi-vault.