### PR TITLE
RWA-2998 - Drop constraints in replica database

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
@@ -461,6 +461,7 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                     return true;
                 });
     }
+
     @Test
     void should_save_task_and_get_task_from_task_assignments_with_taskName_null() {
         TaskResource taskResource = createAndAssignTask();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
@@ -435,6 +435,59 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                 });
     }
 
+    @Test
+    void should_save_task_and_get_task_from_task_assignments_with_location_null() {
+        TaskResource taskResource = createAndAssignTask();
+        taskResource.setLocation(null);
+        checkHistory(taskResource.getTaskId(), 1);
+
+        await().ignoreException(AssertionFailedError.class)
+            .pollInterval(1, SECONDS)
+            .atMost(10, SECONDS)
+            .until(
+                () -> {
+                    List<TaskAssignmentsResource> taskAssignmentsList
+                        = miReportingServiceForTest.findByAssignmentsTaskId(taskResource.getTaskId());
+
+                    assertFalse(taskAssignmentsList.isEmpty());
+                    assertEquals(1, taskAssignmentsList.size());
+                    assertEquals(taskResource.getTaskId(), taskAssignmentsList.get(0).getTaskId());
+                    assertEquals(taskResource.getTaskName(), taskAssignmentsList.get(0).getTaskName());
+                    assertEquals(taskResource.getAssignee(), taskAssignmentsList.get(0).getAssignee());
+                    assertEquals(taskResource.getJurisdiction(), taskAssignmentsList.get(0).getService());
+                    assertNull(taskAssignmentsList.get(0).getAssignmentEnd());
+                    assertNull(taskAssignmentsList.get(0).getAssignmentEndReason());
+
+                    return true;
+                });
+    }
+    @Test
+    void should_save_task_and_get_task_from_task_assignments_with_taskName_null() {
+        TaskResource taskResource = createAndAssignTask();
+        taskResource.setTaskName(null);
+        checkHistory(taskResource.getTaskId(), 1);
+
+        await().ignoreException(AssertionFailedError.class)
+            .pollInterval(1, SECONDS)
+            .atMost(10, SECONDS)
+            .until(
+                () -> {
+                    List<TaskAssignmentsResource> taskAssignmentsList
+                        = miReportingServiceForTest.findByAssignmentsTaskId(taskResource.getTaskId());
+
+                    assertFalse(taskAssignmentsList.isEmpty());
+                    assertEquals(1, taskAssignmentsList.size());
+                    assertEquals(taskResource.getTaskId(), taskAssignmentsList.get(0).getTaskId());
+                    assertEquals(taskResource.getTaskName(), taskAssignmentsList.get(0).getTaskName());
+                    assertEquals(taskResource.getAssignee(), taskAssignmentsList.get(0).getAssignee());
+                    assertEquals(taskResource.getJurisdiction(), taskAssignmentsList.get(0).getService());
+                    assertNull(taskAssignmentsList.get(0).getAssignmentEnd());
+                    assertNull(taskAssignmentsList.get(0).getAssignmentEndReason());
+
+                    return true;
+                });
+    }
+
     @ParameterizedTest
     @CsvSource(value = {
         "COMPLETED,Complete,COMPLETED, COMPLETED",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
@@ -479,7 +479,6 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                     assertFalse(taskAssignmentsList.isEmpty());
                     assertEquals(1, taskAssignmentsList.size());
                     assertEquals(taskResource.getTaskId(), taskAssignmentsList.get(0).getTaskId());
-                    assertEquals(taskResource.getTaskName(), taskAssignmentsList.get(0).getTaskName());
                     assertEquals(taskResource.getAssignee(), taskAssignmentsList.get(0).getAssignee());
                     assertEquals(taskResource.getJurisdiction(), taskAssignmentsList.get(0).getService());
                     assertNull(taskAssignmentsList.get(0).getAssignmentEnd());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
@@ -896,11 +896,11 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
 
         TaskResource taskResource = new TaskResource(
             UUID.randomUUID().toString(),
-            "someNewCaseId",
-            "someJurisdiction",
-            "someLocation",
-            "someRoleCategory",
-            "someTaskName");
+            caseId,
+            jurisdiction,
+            location,
+            roleCategory,
+            taskName);
 
         taskResource.setDueDateTime(OffsetDateTime.parse("2023-04-05T20:15:45.345875+01:00"));
         taskResource.setLastUpdatedTimestamp(OffsetDateTime.parse("2023-03-29T20:15:45.345875+01:00"));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmanagementapi/services/MIReplicaReportingServiceTest.java
@@ -411,7 +411,9 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
 
     @Test
     void should_save_task_and_get_task_from_task_assignments() {
-        TaskResource taskResource = createAndAssignTask();
+        TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+                                                        "someLocation", "someRoleCategory",
+                                                        "someTaskName");;
         checkHistory(taskResource.getTaskId(), 1);
 
         await().ignoreException(AssertionFailedError.class)
@@ -437,8 +439,9 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
 
     @Test
     void should_save_task_and_get_task_from_task_assignments_with_location_null() {
-        TaskResource taskResource = createAndAssignTask();
-        taskResource.setLocation(null);
+        TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+            null, "someRoleCategory",
+                                                        "someTaskName");;
         checkHistory(taskResource.getTaskId(), 1);
 
         await().ignoreException(AssertionFailedError.class)
@@ -457,15 +460,16 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                     assertEquals(taskResource.getJurisdiction(), taskAssignmentsList.get(0).getService());
                     assertNull(taskAssignmentsList.get(0).getAssignmentEnd());
                     assertNull(taskAssignmentsList.get(0).getAssignmentEndReason());
-
+                    assertNull(taskResource.getLocation());
                     return true;
                 });
     }
 
     @Test
     void should_save_task_and_get_task_from_task_assignments_with_taskName_null() {
-        TaskResource taskResource = createAndAssignTask();
-        taskResource.setTaskName(null);
+        TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+                                                        "someLocation", "someRoleCategory",
+                                                        null);;
         checkHistory(taskResource.getTaskId(), 1);
 
         await().ignoreException(AssertionFailedError.class)
@@ -483,7 +487,7 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                     assertEquals(taskResource.getJurisdiction(), taskAssignmentsList.get(0).getService());
                     assertNull(taskAssignmentsList.get(0).getAssignmentEnd());
                     assertNull(taskAssignmentsList.get(0).getAssignmentEndReason());
-
+                    assertNull(taskResource.getTaskName());
                     return true;
                 });
     }
@@ -623,7 +627,9 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
 
     @Test
     void should_save_task_and_record_multiple_task_assignments() {
-        TaskResource taskResource = createAndAssignTask();
+        TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+                                                        "someLocation", "someRoleCategory",
+                                                        "someTaskName");;
         checkHistory(taskResource.getTaskId(), 1);
         taskResource.setLastUpdatedAction("Unclaim");
         taskResource.setState(CFTTaskState.UNASSIGNED);
@@ -885,7 +891,8 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
         return taskResourceRepository.save(taskResource);
     }
 
-    private TaskResource createAndAssignTask() {
+    private TaskResource createAndAssignTask(String caseId, String jurisdiction, String location, String roleCategory,
+                                             String taskName) {
 
         TaskResource taskResource = new TaskResource(
             UUID.randomUUID().toString(),
@@ -958,7 +965,9 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
     @Test
     public void should_test_mark_functionality_with_refresh() {
 
-        TaskResource taskResource = createAndAssignTask();
+        TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+                                                        "someLocation", "someRoleCategory",
+                                                        "someTaskName");;
 
         List<OffsetDateTime> origTaskAssignmentReportRefreshTimes = new ArrayList<>();
         await().ignoreException(AssertionFailedError.class)
@@ -1614,7 +1623,9 @@ class MIReplicaReportingServiceTest extends ReplicaBaseTest {
                                                  Integer expectedProcessed) {
         List<TaskResource> tasks = new ArrayList<>();
         IntStream.range(0, taskResourcesToCreate).forEach(x -> {
-            TaskResource taskResource = createAndAssignTask();
+            TaskResource taskResource = createAndAssignTask("someNewCaseId", "someJurisdiction",
+                                                            "someLocation", "someRoleCategory",
+                                                            "someTaskName");
             log.info(taskResource.toString());
             tasks.add(taskResource);
         });

--- a/src/main/resources/dbreplica/migration/V1.0.25__drop_unnecessary_constraint_replica.sql
+++ b/src/main/resources/dbreplica/migration/V1.0.25__drop_unnecessary_constraint_replica.sql
@@ -1,0 +1,7 @@
+ALTER TABLE task_assignments
+  ALTER COLUMN location DROP NOT NULL;
+
+ALTER TABLE task_assignments
+  ALTER COLUMN task_name DROP NOT NULL;
+
+

--- a/src/main/resources/dbreplica/migration/V1.0.25__drop_unnecessary_constraint_replica.sql
+++ b/src/main/resources/dbreplica/migration/V1.0.25__drop_unnecessary_constraint_replica.sql
@@ -1,7 +1,7 @@
-ALTER TABLE task_assignments
+ALTER TABLE cft_task_db.task_assignments
   ALTER COLUMN location DROP NOT NULL;
 
-ALTER TABLE task_assignments
+ALTER TABLE cft_task_db.task_assignments
   ALTER COLUMN task_name DROP NOT NULL;
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-2998

### Change description ###

Drop constraints in replica database to match to primary

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
